### PR TITLE
Proper encoding declaration for all inspector scraper files.

### DIFF
--- a/inspectors/dhs.py
+++ b/inspectors/dhs.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 from utils import utils, inspector
 from bs4 import BeautifulSoup

--- a/inspectors/doj.py
+++ b/inspectors/doj.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 
 # - Some documents don't have dates, in that case today's date is used
 # - Some forms, marked index are one html document spread across several links,

--- a/inspectors/epa.py
+++ b/inspectors/epa.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 
 import datetime
 from urllib.parse import urljoin

--- a/inspectors/opm.py
+++ b/inspectors/opm.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 from utils import utils, inspector
 from bs4 import BeautifulSoup

--- a/inspectors/usps.py
+++ b/inspectors/usps.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 from utils import utils, inspector
 from bs4 import BeautifulSoup


### PR DESCRIPTION
Based on warnings I was getting in emacs, and on https://docs.python.org/3.4/library/codecs.html#standard-encodings
