### PR TITLE
Windows compatibility - "which" is not available

### DIFF
--- a/inspectors/utils/utils.py
+++ b/inspectors/utils/utils.py
@@ -125,7 +125,7 @@ def text_from_html(html_path):
 def text_from_pdf(pdf_path):
   try:
     subprocess.Popen(["pdftotext", "-v"], shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT).communicate()
-  except Exception:
+  except FileNotFoundError:
     logging.warn("Install pdftotext to extract text! The pdftotext executable must be in a directory that is in your PATH environment variable.")
     return None
 


### PR DESCRIPTION
Just try calling pdftotext and see if it raises an exception

For whatever reason, the msysgit distribution includes pdftotext, so if you run the scraper from your git bash shell, everything works. If you run the scraper from a Windows shell, you just get a warning message, and no conversion is done.

"which" doesn't work even when running from the git bash shell, because msysgit's "which" is actually implemented as a bash script. That didn't work with subprocess.Popen, since Python talks directly to Windows, and Windows doesn't think the "which" file is executable.
