### PR TITLE
Department of Energy IG scraper

### DIFF
--- a/inspectors/energy.py
+++ b/inspectors/energy.py
@@ -22,21 +22,14 @@ from utils import utils, inspector
 #            MA   - Management & Administration
 #            NSS  - National Security & Safety
 #            SI   - Science & Innovation
-#
-#   type - target the specific types for downloading reports, comma-separated.
-#          These corresponds to the links in the left hand side of the report
-#          site, such as "Calendar Year Reports" or "DOE Directives". This can
-#          be specified along with --topics and the union of the two will be
-#          fetched.
-#          Type codes are:
-#          RA   - American Recovery and Reinvestment Act
-#          PR   - Peer Reviews
-#          DOED - Department of Energy Directives
-#          P    - Performance
-#          SP   - Strategic Plan
-#          T    - Testimony
-#          FS   - Financial Statements
-#          SR   - Semiannual Reports
+#            RA   - American Recovery and Reinvestment Act
+#            PR   - Peer Reviews
+#            DOED - Department of Energy Directives
+#            P    - Performance
+#            SP   - Strategic Plan
+#            T    - Testimony
+#            FS   - Financial Statements
+#            SR   - Semiannual Reports
 #
 
 BASE_URL = 'http://energy.gov/ig/calendar-year-reports'
@@ -48,9 +41,6 @@ TOPIC_TO_URL = {
   'MA': 'http://energy.gov/ig/listings/management-administration-reports',
   'NSS': 'http://energy.gov/ig/listings/national-security-safety-reports',
   'SI': 'http://energy.gov/ig/listings/science-innovation-reports',
-}
-
-TYPE_TO_URL = {
   'RA': 'http://energy.gov/ig/listings/recovery-act-reports',
   'PR': 'http://energy.gov/ig/calendar-year-reports/peer-reviews',
   'DOED': 'http://energy.gov/ig/calendar-year-reports/doe-directives',
@@ -62,148 +52,207 @@ TYPE_TO_URL = {
   'WP': 'http://energy.gov/ig/calendar-year-reports/work-plans-manuals',
 }
 
+# Reports in these topics are not listed in the normal "Calendar Year" reports.
+# When we get no specification for topics, we will scrape all of the relevant
+# Calendar Year pages, as well as the pages for these topics in order to be
+# comprehensive.
+# These are tuples of the topic code and the report_type that should be used
+# when scraping reports of that topic
+ADDITIONAL_TOPICS= [
+  ('PR', 'peer_review'),
+  ('DOED', 'doe_directive'),
+  ('P', 'performance_plan'),
+  ('SP', 'strategic_plan'),
+  ('T', 'testimony'),
+  ('SR', 'semiannual_report'),
+]
+TOPIC_TO_REPORT_TYPE = dict(ADDITIONAL_TOPICS)
+
 RE_CALENDAR_YEAR = re.compile(r'Calendar Year (\d{4})')
-RE_REPORT_ID = re.compile('(.+): (.+)')
+RE_REPORT_ID = re.compile('(.+): (\S+[-/]\S+)')
 RE_NOT_AVAILABLE = re.compile('not available for viewing', re.I)
 RE_CLASSIFIED = re.compile('report is classified', re.I)
 
-def run(options):
-  for url in urls_for(options):
-    page = BeautifulSoup(utils.download(url))
+class EnergyScraper(object):
+  def run(self, options):
+    self.options = options
+    self.year_range = inspector.year_range(self.options)
+    self.first_date = datetime.datetime(self.year_range[0], 1, 1)
+    self.last_date = datetime.datetime(self.year_range[-1], 12, 31)
 
-    for node in page.select('.node'):
-      report = report_from(node)
-      if report:
-        inspector.save_report(report)
+    for url in self.urls_for():
+      page = BeautifulSoup(utils.download(url))
 
-def report_from(node):
-  report = {
-    'inspector': 'energy',
-    'inspector_url': 'http://energy.gov/ig/office-inspector-general',
-    'agency': 'energy',
-    'agency_name': 'Department of Energy',
-  }
+      nodes = page.select('.energy-listing__results .node')
+      if not nodes:
+        nodes = page.select('.field-items .node')
+      if not nodes:
+        nodes = page.select('.node')
 
-  date = node.select('.date')[0]
-  published_on = datetime.datetime.strptime(date.text, '%B %d, %Y')
-  published_on = published_on.strftime('%Y-%m-%d')
+      for node in nodes:
+        report = self.report_from(node)
+        if report:
+          inspector.save_report(report)
+        else:
+          # Empty report indicates a report out of the date range. There will
+          # be no more good reports on this page.
+          break
 
-  title_p = node.select('.field-item p')[0]
-  title = title_p.text.strip()
+  def report_from(self, node):
+    report = {
+      'inspector': 'energy',
+      'inspector_url': 'http://energy.gov/ig/office-inspector-general',
+      'agency': 'energy',
+      'agency_name': 'Department of Energy',
+    }
 
-  title_link = node.select('.title-link')[0]
-  landing_url = urljoin(BASE_URL, title_link['href'])
+    date = node.select('.date')[0]
+    published_on = datetime.datetime.strptime(date.text, '%B %d, %Y')
+    if published_on < self.first_date or published_on > self.last_date:
+      # Out of date range, skip this one.
+      return
+    published_on = published_on.strftime('%Y-%m-%d')
 
-  title_link_span = title_link.select('span')[0]
-  md = RE_REPORT_ID.search(title_link_span.text)
-  if md:
-    sub_type = md.group(1).strip().replace(' ', '_').lower()
-    report_id = md.group(2).strip().replace('/', '-')
-  else:
-    title_slug = re.sub(r'\W', '', title[:16])
-    report_id = (published_on + '-' + title_slug)
+    title_p = node.select('.field-item p')[0]
+    title = title_p.text.strip()
 
-  report_url, summary, unreleased = fetch_from_landing_page(landing_url)
+    title_link = node.select('.title-link')[0]
+    landing_url = urljoin(BASE_URL, title_link['href'])
 
-  if unreleased:
-    report['unreleased'] = True
-
-  report.update({
-    'report_id': report_id,
-    'type': 'report',
-    'sub_type': sub_type,
-    'url': report_url,
-    'landing_url': landing_url,
-    'summary': summary,
-    'title': title,
-    'published_on': published_on
-  })
-  return report
-  
-def fetch_from_landing_page(landing_url):
-  """Returns a tuple of (pdf_link, summary_text, is_unreleased)."""
-  unreleased = False
-  page = BeautifulSoup(utils.download(landing_url))
-
-  summary = None
-  field_items = page.select('.field-items')
-  if field_items:
-    text = [node.strip() for node in field_items[0].findAll(text=True)]
-    summary = '\n\n'.join(text)
-  if not summary:
-    logging.info('\tno summary text found')
-
-  if (summary and (RE_NOT_AVAILABLE.search(summary)
-                   or RE_CLASSIFIED.search(summary))):
-    unreleased = True
-
-  report_url = None
-  pdf_link = page.select('.file a')
-  if not pdf_link:
-    logging.warn('No pdf link found on page: {0}'.format(landing_url))
-  else:
-    report_url = pdf_link[0]['href']
-
-  return report_url, summary, unreleased
-
-def urls_for(options):
-  type_ = options.get('type')
-  if type_:
-    # TODO: Do something with types
-    pass
-
-  only = options.get('topics')
-  if only:
-    only = set(only.split(','))
-    yield from urls_for_topics(options, only)
-    return
-
-  # Not getting reports from specific topics, iterate over all Calendar Year
-  # reports.
-  year_range = inspector.year_range(options)
-  url = BASE_URL
-
-  page = BeautifulSoup(utils.download(url))
-
-  # Iterate over each "Calendar Year XXXX" link
-  for li in page.select('.field-items li'):
-    md = RE_CALENDAR_YEAR.search(li.text)
+    title_link_span = title_link.select('span')[0]
+    md = RE_REPORT_ID.search(title_link_span.text)
     if md:
-      cur_year = int(md.group(1))
-      if cur_year >= year_range[0] and cur_year <= year_range[-1]:
-        href = li.select('a')[0]['href']
-        next_url = urljoin(url, href)
-        # The first page of reports is yielded.
-        yield next_url
+      report['sub_type'] = md.group(1).strip().replace(' ', '_').lower()
+      report_id = md.group(2).strip().replace('/', '-')
+    else:
+      title_slug = re.sub(r'\W', '', title[:16])
+      report_id = (published_on + '-' + title_slug)
 
-        # Next, read all the pagination links for the page and yield those. So
-        # far, I haven't seen a page that doesn't have all of the following
-        # pages enumerated.
+    report_url, summary, unreleased = self.fetch_from_landing_page(landing_url)
+
+    if unreleased:
+      report['unreleased'] = True
+
+    report.update({
+      'report_id': report_id,
+      'type': self.report_type if self.report_type else 'report',
+      'url': report_url,
+      'landing_url': landing_url,
+      'summary': summary,
+      'title': title,
+      'published_on': published_on
+    })
+    return report
+
+  def fetch_from_landing_page(self, landing_url):
+    """Returns a tuple of (pdf_link, summary_text, is_unreleased)."""
+    unreleased = False
+    page = BeautifulSoup(utils.download(landing_url))
+
+    summary = None
+    field_items = page.select('.field-items')
+    if field_items:
+      text = [node.strip() for node in field_items[0].findAll(text=True)]
+      summary = '\n\n'.join(text)
+    if not summary:
+      logging.info('\tno summary text found')
+
+    if (summary and (RE_NOT_AVAILABLE.search(summary)
+                     or RE_CLASSIFIED.search(summary))):
+      unreleased = True
+
+    report_url = None
+    pdf_link = page.select('.file a')
+    if not pdf_link:
+      logging.warn('No pdf link found on page: {0}'.format(landing_url))
+    else:
+      report_url = pdf_link[0]['href']
+
+    return report_url, summary, unreleased
+
+  def urls_for(self):
+    only = self.options.get('topics')
+    if only:
+      only = set(only.split(','))
+      only = [(o, TOPIC_TO_REPORT_TYPE[o]) if o in TOPIC_TO_REPORT_TYPE else o 
+              for o in only]
+      yield from self.urls_for_topics(only)
+      # If there are topics selected, ONLY yield URLs for those.
+      return
+
+    # First yield the URLs for the topics that are tangential to the main
+    # Calendar Year reports.
+    yield from self.urls_for_topics(ADDITIONAL_TOPICS)
+
+    # Not getting reports from specific topics, iterate over all Calendar Year
+    # reports.
+    page = BeautifulSoup(utils.download(BASE_URL))
+
+    # Iterate over each "Calendar Year XXXX" link
+    for li in page.select('.field-items li'):
+      md = RE_CALENDAR_YEAR.search(li.text)
+      if md:
+        cur_year = int(md.group(1))
+        if cur_year >= self.year_range[0] and cur_year <= self.year_range[-1]:
+          href = li.select('a')[0]['href']
+          next_url = urljoin(BASE_URL, href)
+          # The first page of reports is yielded.
+          yield next_url
+
+          # Next, read all the pagination links for the page and yield those. So
+          # far, I haven't seen a page that doesn't have all of the following
+          # pages enumerated.
+          next_page = BeautifulSoup(utils.download(next_url))
+          for link in next_page.select('li.pager-item a'):
+            yield urljoin(BASE_URL, link['href'])
+
+
+  def urls_for_topics(self, topics):
+    for topic in topics:
+      # Topic might be a tuple for ADDITIONAL_TOPICS (not ones from command
+      # line).
+      self.report_type = None
+      if isinstance(topic, tuple):
+        topic, report_type = topic
+        self.report_type = report_type
+
+      last_page = False
+
+      url = TOPIC_TO_URL[topic]
+      page = BeautifulSoup(utils.download(url))
+      page_started = self.is_first_page(page)
+      if page_started:
+        yield url
+
+      for link in page.select('li.pager-item a'):
+        next_url = urljoin(url, link['href'])
         next_page = BeautifulSoup(utils.download(next_url))
-        for link in next_page.select('li.pager-item a'):
-          yield urljoin(url, link['href'])
+        if not page_started:
+          page_started = self.is_first_page(next_page)
+        if page_started:
+          yield next_url
+        last_page = self.is_last_page(next_page)
+        if last_page:
+          break
+      if last_page:
+        continue
+    self.report_type = None  # Clear this out afterwards
 
-def urls_for_topics(options, only):
-  year_range = inspector.year_range(options)
-  first_date = datetime.datetime(year_range[0], 1, 1)
-
-  for topic in only:
-    url = TOPIC_TO_URL[topic]
-    yield url
-
-    page = BeautifulSoup(utils.download(url))
-
-    is_last_page = False
+  def is_first_page(self, page):
     for date in page.select('.date'):
       cur_date = datetime.datetime.strptime(date.text.strip(), '%B %d, %Y')
-      if cur_date < first_date:
-        is_last_page = True
-        break
-    if is_last_page:
-      continue
-    
-    for link in page.select('li.pager-item a'):
-      yield urljoin(url, link['href'])
+      if cur_date <= self.last_date:
+        return True
+    return False  
 
+  def is_last_page(self, page):
+    for date in page.select('.date'):
+      cur_date = datetime.datetime.strptime(date.text.strip(), '%B %d, %Y')
+      if cur_date < self.first_date:
+        return True
+    return False
+
+def run(options):
+  EnergyScraper().run(options)
 
 utils.run(run) if (__name__ == "__main__") else None


### PR DESCRIPTION
The interesting things here is that we scrape out a "sub_type" for the report based on things like:

"Special Inquiry: DOE/IG-0910" -- 'special_inquiry'
and
"Management Alert: DOE/IG-0906" -- 'management_alert'

These didn't seem like topics, offices, or categories, so that's why I made them sub types.

This is an IG site that includes landing pages and summaries, which this scraper extracts.

We also detect reports that are unreleased by checking if their summary pages for 'report is classified' and 'not available for viewing', because sometimes classified reports from this IG have a stub PDF that simply says "This report is classified. For information on.....".

For some categories of reports ('topics') we use a report 'type' other than report. These are listed in the code under ADDITIONAL_TOPICS.

Also, this is the first scraper that is a class. I was sick of passing around options and year_range and the like, mainly. But I also genuinely needed to set the state of the class in one method that was used by a higher up method, for the report_type.
