### PR TITLE
Fixes SEC scraper issues discovered in 3046897a687e7839379bcfa074274a61c8ccc8f0.

### DIFF
--- a/inspectors/sec.py
+++ b/inspectors/sec.py
@@ -114,7 +114,7 @@ def report_from(result, landing_url, topic, year_range, last_published_on):
 
   if published_on.year not in year_range:
     logging.debug("[%s] Skipping, not in requested range." % landing_url)
-    return None, None
+    return None, published_on
 
   logging.debug("### Processing report %s" % report_link)
 


### PR DESCRIPTION
The problem is that we want to continue to pass the published_on
datetime so that last_published_on will be set for the next iteration
even though the current published_on is not in the year range.

The next report won't have a published_on in year_range either, but this
seems like the cleanest solution.
