### PR TITLE
Fix issue #53, getting annotations as part of the report title.

### DIFF
--- a/inspectors/epa.py
+++ b/inspectors/epa.py
@@ -123,7 +123,9 @@ def report_from(tds, published_on_dt, year):
 
   published_on = datetime.datetime.strftime(published_on_dt, '%Y-%m-%d')
 
-  title = tds[1].text.strip()
+  # Don't take all the text because it can sometimes include a <br> and some
+  # annotation.
+  title = tds[1].contents[0].strip()
   if not report_id:
     title_slug = re.sub(r'\W', '', title[:16])
     report_id = (published_on + '-' + title_slug)


### PR DESCRIPTION
Fixes #53.

It seems like the first text node in the `<td>` contents is always the title. I ran this on the default/first page of results, before and after this patch, and it resulted in the following diff:

```
$ diff -ur data data_old/
diff -ur data/epa/2014/14-P-0154/report.json data_old/epa/2014/14-P-0154/report.json
--- data/epa/2014/14-P-0154/report.json 2014-06-15 20:19:07.000000000 -0700
+++ data_old/epa/2014/14-P-0154/report.json 2014-06-15 20:18:16.000000000 -0700
@@ -8,7 +8,7 @@
   "report_id": "14-P-0154",
   "summary_only": false,
   "summary_url": "http://www.epa.gov/oig/reports/2014/20140331-14-P-0154_glance.pdf",
-  "title": "Improvements to EPA Policies and Guidance Could Enhance Protection of Human Study Subjects",
+  "title": "Improvements to EPA Policies and Guidance Could Enhance Protection of Human Study Subjects      \r\n          Podcast: Report Overview with Renee McGhee-Lenart (MP3 - 3.9 MBs, 5:41),\r\n   \t\t\tPodcast Transcript",
   "type": "report",
   "url": "http://www.epa.gov/oig/reports/2014/20140331-14-P-0154.pdf",
   "year": 2014
diff -ur data/epa/2014/14-P-0262/report.json data_old/epa/2014/14-P-0262/report.json
--- data/epa/2014/14-P-0262/report.json 2014-06-15 20:19:07.000000000 -0700
+++ data_old/epa/2014/14-P-0262/report.json 2014-06-15 20:18:16.000000000 -0700
@@ -8,7 +8,7 @@
   "report_id": "14-P-0262",
   "summary_only": false,
   "summary_url": "http://www.epa.gov/oig/reports/2014/20140516-14-P-0262_glance.pdf",
-  "title": "Briefing Report: Review of EPA's Process to Release Information Under the Freedom of Information Act",
+  "title": "Briefing Report: Review of EPA's Process to Release Information Under the Freedom of Information Act\r\n   This report has been updated to include a statement on generally accepted government auditing standards.",
   "type": "report",
   "url": "http://www.epa.gov/oig/reports/2014/20140516-14-P-0262.pdf",
   "year": 2014
```

Which looks like the improvement we're looking for without any regression to other titles.
