### PR TITLE
Add Commerce Scraper

### DIFF
--- a/inspectors/commerce.py
+++ b/inspectors/commerce.py
@@ -98,12 +98,16 @@ def report_from(result, topic, topic_url, year_range):
       # If there is no linked report, this page is the report. We know that
       # these are not unreleased reports or we would have caught them above
       # based on the title.
-      report_url = landing_url
+      unreleased = True
+      report_url = None
     else:
       report_url = urljoin(topic_url, report_url_relative)
 
-    report_filename = report_url.split("/")[-1]
-    report_id, extension = os.path.splitext(report_filename)
+    if report_url:
+      report_filename = report_url.split("/")[-1]
+      report_id, extension = os.path.splitext(report_filename)
+    else:
+      report_id = "{}-{}".format(published_on_text, "-".join(title.split()))[:50]
 
   if published_on.year not in year_range:
     logging.debug("[%s] Skipping, not in requested range." % report_url)


### PR DESCRIPTION
- Some reports don't have IDs so we fallback to using a combination of the date and title
- [Some reports](http://www.oig.doc.gov/Pages/NOAA-Grantee-Sentenced-for-Misusing-Funds.aspx) don't have a pdf download. For these, I'm just setting that page as the report. Let me know if we should just skip these since they seem a bit more like announcements. [Some](http://www.oig.doc.gov/Pages/NIST-Grantee-Pleads-Guilty-to-Misuse-of-Federal-Funds.aspx) [other](http://www.oig.doc.gov/Pages/Former-Census-Contractor-Sentenced-for-Money-Laundering.aspx) [examples](http://www.oig.doc.gov/Pages/NOAA-Employee-Fired-for-Misuse-of-Purchase-Card.aspx).
- `urllib.parse` has some trouble finding the extension for some of these report urls. See the workaround [here](https://github.com/unitedstates/inspectors-general/commit/6a70ce115100066b615e53f40bdbf54e9ead9812#diff-39ad96d7559d7adf9c1c082619f3ac75R120). 
