### PR TITLE
Add Department of Labor

### DIFF
--- a/inspectors/labor.py
+++ b/inspectors/labor.py
@@ -21,6 +21,7 @@ from utils import utils, inspector
 
 AUDIT_REPORTS_URL = "http://www.oig.dol.gov/cgi-bin/oa_rpts.cgi?s=&y=fy9{}&a=all"
 SEMIANNUAL_REPORTS_URL = "http://www.oig.dol.gov/semiannual.htm"
+BASE_URL = "http://www.oig.dol.gov"
 
 REPORT_PUBLISHED_MAPPING = {
   "02-02-202-03-360": datetime.datetime(2002, 2, 11),
@@ -74,11 +75,11 @@ def report_from(result, year_url):
   report_url, summary_url, response_url = None, None, None
   for link in result.select("a"):
     if 'Report' in link.text:
-      report_url = link.get('href')
+      report_url = urljoin(BASE_URL, link.get('href'))
     elif 'Summary' in link.text:
-      summary_url = link.get('href')
+      summary_url = urljoin(BASE_URL, link.get('href'))
     elif 'Response' in link.text:
-      response_url = link.get('href')
+      response_url = urljoin(BASE_URL, link.get('href'))
 
   UNRELEASED_TEXTS = [
     "This report will not be posted.",


### PR DESCRIPTION
So I was pretty happy with this agency-based approached (still need to add semiannual reports) until I started adding up the numbers.

This scraper that goes agency by agency results in 733 reports while just searching for [all reports](http://www.oig.dol.gov/cgi-bin/oa_rpts.cgi?s=&y=all&a=all) results in 824 reports. It appears that some reports are not tagged appropriately with their agency.

For example, report 08-OEI-97-MSHA from http://www.oig.dol.gov/cgi-bin/oa_rpts+.cgi?s=&y=all&a=all&next_i=820 certainly should fall under Mine Safety and Health Administration, but it is not listed on http://www.oig.dol.gov/cgi-bin/oa_rpts.cgi?s=&y=all&a=06 (the MSHA filter).

There does not appear to be any easy way to deduce the agency just based on the listing. My next plan is to throw most of this work away and just use the general listing for all reports. I wanted to check in and see if any other ideas came up.
