### PR TITLE
Replace "%s/%s" with os.path.join()

### DIFF
--- a/inspectors/dod.py
+++ b/inspectors/dod.py
@@ -162,7 +162,7 @@ def report_from(tds, options):
       'inspector': 'dod'
     }, 'pdf')
 
-    if os.path.exists("%s/%s" % (utils.data_dir(), pdf_path)):
+    if os.path.exists(os.path.join(utils.data_dir(), pdf_path)):
       logging.warn("\tSkipping previously downloaded report, as asked.")
       return
 

--- a/inspectors/utils/inspector.py
+++ b/inspectors/utils/inspector.py
@@ -145,7 +145,7 @@ def download_report(report):
 
   result = utils.download(
     report['url'],
-    "%s/%s" % (utils.data_dir(), report_path),
+    os.path.join(utils.data_dir(), report_path),
     {'binary': binary}
   )
   if result:
@@ -187,13 +187,13 @@ def write_report(report):
 
   utils.write(
     utils.json_for(report),
-    "%s/%s" % (utils.data_dir(), data_path)
+    os.path.join(utils.data_dir(), data_path)
   )
   return data_path
 
 
 def path_for(report, ext):
-  return "%s/%s/%s/report.%s" % (report['inspector'], report['year'], report['report_id'], ext)
+  return os.path.join(report['inspector'], str(report['year']), report['report_id'], "report.%s" % ext)
 
 def cache(inspector, path):
   return os.path.join(utils.cache_dir(), inspector, path)


### PR DESCRIPTION
This is a small change, but it's more "Pythonic," and it results in using the appropriate path separator for the OS.
