### PR TITLE
Remove shell=True from PDF extraction routines

### DIFF
--- a/inspectors/utils/utils.py
+++ b/inspectors/utils/utils.py
@@ -138,7 +138,7 @@ def text_from_pdf(pdf_path):
   real_text_path = os.path.join(data_dir(), text_path)
 
   try:
-    subprocess.check_call("pdftotext -layout \"%s\" \"%s\"" % (real_pdf_path, real_text_path), shell=True)
+    subprocess.check_call("pdftotext -layout \"%s\" \"%s\"" % (real_pdf_path, real_text_path))
   except subprocess.CalledProcessError as exc:
     logging.warn("Error extracting text to %s:\n\n%s" % (text_path, format_exception(exc)))
     return None
@@ -159,7 +159,7 @@ def page_count_from_pdf(pdf_path):
   real_pdf_path = os.path.join(data_dir(), pdf_path)
 
   try:
-    output = subprocess.check_output("pdfinfo \"%s\"" % (real_pdf_path), shell=True)
+    output = subprocess.check_output("pdfinfo \"%s\"" % (real_pdf_path))
   except subprocess.CalledProcessError as exc:
     logging.warn("Error extracting page count for %s:\n\n%s" % (pdf_path, format_exception(exc)))
     return None


### PR DESCRIPTION
Fixes #84. We weren't actually using the shell for anything, so this is all we need to change.
