### PR TITLE
Remove the utf-8 encoding line at the top of executable files

### DIFF
--- a/inspectors/agriculture.py
+++ b/inspectors/agriculture.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import datetime
 import logging

--- a/inspectors/amtrak.py
+++ b/inspectors/amtrak.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 from utils import utils, inspector
 from bs4 import BeautifulSoup

--- a/inspectors/commerce.py
+++ b/inspectors/commerce.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import datetime
 import logging

--- a/inspectors/dhs.py
+++ b/inspectors/dhs.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 from utils import utils, inspector
 from bs4 import BeautifulSoup

--- a/inspectors/dod.py
+++ b/inspectors/dod.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import datetime
 from urllib.parse import urljoin, urlencode

--- a/inspectors/doj.py
+++ b/inspectors/doj.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 # - Some documents don't have dates, in that case today's date is used
 # - Some forms, marked index are one html document spread across several links,

--- a/inspectors/dot.py
+++ b/inspectors/dot.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import datetime
 from urllib.parse import urljoin, urlencode

--- a/inspectors/energy.py
+++ b/inspectors/energy.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import datetime
 from urllib.parse import urljoin, urlencode

--- a/inspectors/epa.py
+++ b/inspectors/epa.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import datetime
 from urllib.parse import urljoin

--- a/inspectors/exim.py
+++ b/inspectors/exim.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 from utils import utils, inspector
 from bs4 import BeautifulSoup

--- a/inspectors/fcc.py
+++ b/inspectors/fcc.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import datetime
 import logging

--- a/inspectors/fed.py
+++ b/inspectors/fed.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import datetime
 import logging

--- a/inspectors/gao.py
+++ b/inspectors/gao.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import datetime
 import logging

--- a/inspectors/gsa.py
+++ b/inspectors/gsa.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 from utils import utils, inspector
 from bs4 import BeautifulSoup

--- a/inspectors/hhs.py
+++ b/inspectors/hhs.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import datetime
 import logging

--- a/inspectors/hud.py
+++ b/inspectors/hud.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import datetime
 import logging

--- a/inspectors/interior.py
+++ b/inspectors/interior.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import datetime
 import logging

--- a/inspectors/labor.py
+++ b/inspectors/labor.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import datetime
 import logging

--- a/inspectors/opm.py
+++ b/inspectors/opm.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 from utils import utils, inspector
 from bs4 import BeautifulSoup

--- a/inspectors/sec.py
+++ b/inspectors/sec.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import datetime
 import logging

--- a/inspectors/state.py
+++ b/inspectors/state.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import datetime
 import logging

--- a/inspectors/treasury.py
+++ b/inspectors/treasury.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import datetime
 import logging

--- a/inspectors/usps.py
+++ b/inspectors/usps.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 from utils import utils, inspector
 from bs4 import BeautifulSoup

--- a/inspectors/va.py
+++ b/inspectors/va.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import datetime
 import logging

--- a/scraper.py.template
+++ b/scraper.py.template
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 from utils import utils, inspector
 


### PR DESCRIPTION
This is no longer needed, now that the project is all Python 3.

I've updated `scraper.py.template` as well.
