### PR TITLE
Add check for published_on in exim.py

### DIFF
--- a/inspectors/exim.py
+++ b/inspectors/exim.py
@@ -64,7 +64,7 @@ def run(options):
           published_on = datetime.strptime(date_text, '%B %d, %Y')
         except ValueError:
           published_on = datetime.strptime(date_text, '%b %d, %Y')
-      if published_on.year not in year_range:
+      if (published_on is None) or (published_on.year not in year_range):
         continue
 
       report = report_from(all_text, a_text, a_href, page_url, published_on)


### PR DESCRIPTION
If you don't get into the `if temp:` block, `published_on` is not set, which leads to an error.

The offending, unprocessable link (from http://www.exim.gov/oig/index.cfm):
![photo](https://api.monosnap.com/image/download?id=cFPH7C5XpXMXrV5YntJaMNEXfNCsEr)
