### PR TITLE
Check for empty <tr> in pbgc scraper before attempting to set variable b...

### DIFF
--- a/inspectors/pbgc.py
+++ b/inspectors/pbgc.py
@@ -47,7 +47,7 @@ def run(options):
       if report:
         inspector.save_report(report)
 
-  # Pull the congreesional requests
+  # Pull the congressional requests
   doc = BeautifulSoup(utils.download(CONGRESSIONAL_REQUESTS_URL))
   results = doc.select("tr")
   for result in results:
@@ -72,7 +72,11 @@ def run(options):
       inspector.save_report(report)
 
 def report_from(result, report_type, year_range):
-  title = result.select("td")[0].text.strip()
+  if len(result.select("td")) > 0:
+    title = result.select("td")[0].text.strip()
+  else:
+    return
+
   if title in HEADER_ROW_TEXT:
     # Skip the header rows
     return


### PR DESCRIPTION
Some of the markup on the PBGC site isn't valid (using tr with no slash as a closing tag), which is causing trouble:

```
            <tr>
                <td  style='border:1px solid #86b2d8;'><a href='pdfs/LTR-2014-09.pdf' target='_blank'>OIG Response to Rep. Turner Request - Delphi Salaried Pension Plan Delays</a></td>
                <td style='border:1px solid #86b2d8;' align='center'>LTR 2014-13</td>
                <td style='border:1px solid #86b2d8;' align='center'>09/02/2014</td>

            <tr>
```

So this commit just does a check to make sure that the tr has a nested td before doing its thing.
