### PR TITLE
Fixes Slack http logging crash

### DIFF
--- a/inspectors/utils/utils.py
+++ b/inspectors/utils/utils.py
@@ -126,10 +126,6 @@ def log_http_error(e, url):
   print(message)
   if admin.config and admin.config.get("slack"):
     admin.send_slack(message)
-  elif admin.config:
-    print(admin.config.get("slack"))
-  else:
-    print(admin.config)
 
 # uses BeautifulSoup to do a naive extraction of text from HTML,
 # then writes it and returns the /data-relative path.


### PR DESCRIPTION
There's a section of utils that deals with logging http errors from Slack, and it makes a logic error - it was:

``` python
  if admin.config and admin.config.get("slack"):
    admin.send_slack(message)
  else:
    print(admin.config, admin.config.get("slack"))
```

But that means `admin.config.get()` can be called when `admin.config` is `None`. This fixes that:

``` python
  if admin.config and admin.config.get("slack"):
    admin.send_slack(message)
  elif admin.config:
    print(admin.config.get("slack"))
  else:
    print(admin.config)
```
