### PR TITLE
Don't use VA office names for agency name

### DIFF
--- a/inspectors/va.py
+++ b/inspectors/va.py
@@ -145,7 +145,7 @@ def report_from(result, year_range):
     'inspector': 'va',
     'inspector_url': 'http://www.va.gov/oig',
     'agency': agency_slug,
-    'agency_name': agency_name,
+    'agency_name': "Department of Veterans Affairs",
     'report_id': report_id,
     'url': report_url,
     'landing_url': landing_url,


### PR DESCRIPTION
Use `Department of Veterans Affairs`.

Done after seeing "Office of Information and Technology (OIT)" listed as the agency name [on a report](https://scout.sunlightfoundation.com/item/document/ig_report-va-2015-13-03324-85/inspector-general-report-follow-up-audit-of-the-information-technology-project-management-accountability-system).