### PR TITLE
Big batch of scraper fixes

### DIFF
--- a/inspectors/archives.py
+++ b/inspectors/archives.py
@@ -49,7 +49,8 @@ def run(options):
   doc = BeautifulSoup(utils.download(PEER_REVIEWS_URL))
   result = doc.find("div", id='content').find("a", text=True)
   report = peer_review_from(result, year_range)
-  inspector.save_report(report)
+  if report:
+    inspector.save_report(report)
 
 def audit_report_from(result, landing_url, year, year_range):
   link = result.find("a")

--- a/inspectors/energy.py
+++ b/inspectors/energy.py
@@ -92,6 +92,7 @@ RE_NOT_AVAILABLE = re.compile('not available (?:for|of) viewing', re.I)
 RE_NOT_AVAILABLE_2 = re.compile('not publically available', re.I)
 RE_NOT_AVAILABLE_3 = re.compile('official use only', re.I)
 RE_NOT_AVAILABLE_4 = re.compile('to obtain a copy of this report please email', re.I)
+RE_WITHDRAWN = re.compile('report is temporarily unavailable', re.I)
 RE_CLASSIFIED = re.compile('report is classified', re.I)
 
 class EnergyScraper(object):
@@ -202,10 +203,15 @@ class EnergyScraper(object):
     if not summary:
       logging.info('\tno summary text found')
 
+    # sanitize now instead of later, to compare to regexes
+    else:
+      summary = inspector.sanitize(summary)
+
     if (summary and (RE_NOT_AVAILABLE.search(summary)
                      or RE_NOT_AVAILABLE_2.search(summary)
                      or RE_NOT_AVAILABLE_3.search(summary)
                      or RE_NOT_AVAILABLE_4.search(summary)
+                     or RE_WITHDRAWN.search(summary)
                      or RE_CLASSIFIED.search(summary))):
       unreleased = True
 

--- a/inspectors/gpo.py
+++ b/inspectors/gpo.py
@@ -58,11 +58,11 @@ def report_from(result, landing_url, report_type, year_range):
   if "contains sensitive information" in title:
     unreleased = True
     report_url = None
-    report_id = "-".join(title.split())[:50]
+    report_id = inspector.slugify("-".join(title.split())[:50])
   else:
     unreleased = False
     link = result.find("a")
-    report_id = link.text
+    report_id = inspector.slugify(link.text)
     report_url = urljoin(landing_url, link.get('href'))
     if landing_url == SEMIANNUAL_REPORTS_URL:
       if title.find("Transmittal Letter") != -1:

--- a/inspectors/hhs.py
+++ b/inspectors/hhs.py
@@ -185,7 +185,8 @@ def run(options):
   if topics:
     topics = topics.split(",")
   else:
-    topics = TOPIC_TO_URL.keys()
+    topics = list(TOPIC_TO_URL.keys())
+    topics.sort()
 
   for topic in topics:
     extract_reports_for_topic(topic, year_range)
@@ -401,7 +402,7 @@ def report_from_landing_url(report_url):
     relative_url = doc.select("#leftContentInterior p.download a")[0]['href']
   except IndexError:
     try:
-      relative_url = doc.select("#leftContentInterior p a")[0]['href']
+      relative_url = doc.select("#leftContentInterior p a")[-1]['href']
     except IndexError:
       relative_url = None
 

--- a/inspectors/ncua.py
+++ b/inspectors/ncua.py
@@ -30,6 +30,11 @@ def run(options):
     if year < 2002:  # The oldest page for audit reports
       continue
     doc = BeautifulSoup(utils.download(AUDIT_REPORTS_URL.format(year=year)))
+
+    # if it's a 404 page (200 response code), move on
+    if not_found(doc):
+      continue
+
     results = doc.select("div.content table tr")
     for index, result in enumerate(results):
       if not index:
@@ -57,6 +62,9 @@ def run(options):
     report = semiannual_report_from(result, year_range)
     if report:
       inspector.save_report(report)
+
+def not_found(doc):
+  return (doc.select("h2")[0].text.strip().lower() == "page not found")
 
 def clean_text(text):
   # This character is not technically whitespace so we have to manually replace it

--- a/inspectors/nsf.py
+++ b/inspectors/nsf.py
@@ -90,6 +90,10 @@ def run(options):
 def report_from(result, report_type, year_range):
   link = result.find("a")
 
+  if not link:
+    logging.debug("Markup error, skipping: %s" % result)
+    return None
+
   report_url = urljoin(AUDIT_REPORTS_URL, link['href'])
   report_filename = report_url.split("/")[-1]
   report_id, _ = os.path.splitext(report_filename)

--- a/inspectors/pbgc.py
+++ b/inspectors/pbgc.py
@@ -75,11 +75,11 @@ saved_report_urls = set()
 
 def report_from(result, report_type, year_range):
   if len(result.select("td")) > 0:
-    title = result.select("td")[0].text.strip()
+    title = inspector.sanitize(result.select("td")[0].text)
   else:
     return
 
-  if title in HEADER_ROW_TEXT:
+  if (not title) or (title in HEADER_ROW_TEXT):
     # Skip the header rows
     return
 

--- a/inspectors/usps.py
+++ b/inspectors/usps.py
@@ -127,9 +127,13 @@ def type_for(original_type):
     return None
 
 # get the last page number, from a page of search results
-# e.g. <li class="pager-item active last">158</li>
+# e.g. <li class="pager-item active last">of 158</li>
 def last_page_for(doc):
-  page = doc.select("li.pager-item.last")[0].text.replace("of ", "").strip()
+  pagers = doc.select("li.pager-item.last")
+  if len(pagers) == 0:
+    return 1
+
+  page = pagers[0].text.replace("of ", "").strip()
   if page and len(page) > 0:
     return int(page)
 

--- a/inspectors/utils/inspector.py
+++ b/inspectors/utils/inspector.py
@@ -217,6 +217,7 @@ def slugify(report_id):
   copy = report_id
   for char in invalid_chars():
     copy = copy.replace(char, "-")
+  return copy
 
 def download_report(report):
   report_path = path_for(report, report['file_type'])

--- a/inspectors/utils/inspector.py
+++ b/inspectors/utils/inspector.py
@@ -77,7 +77,7 @@ def preprocess_report(report):
   for field in common_strings:
     value = report.get(field)
     if (value is not None):
-      report[field] = value.strip()
+      report[field] = value.replace("\xa0", " ").strip()
 
   # if we have a date, but no explicit year, extract it
   if report.get("published_on") and (report.get('year') is None):

--- a/inspectors/utils/inspector.py
+++ b/inspectors/utils/inspector.py
@@ -77,7 +77,7 @@ def preprocess_report(report):
   for field in common_strings:
     value = report.get(field)
     if (value is not None):
-      report[field] = value.replace("\xa0", " ").strip()
+      report[field] = sanitize(value)
 
   # if we have a date, but no explicit year, extract it
   if report.get("published_on") and (report.get('year') is None):
@@ -203,6 +203,10 @@ def check_uniqueness(inspector, report_id, report_year):
 def verify_uniqueness_finalize_summary():
   if _uniqueness_messages:
     admin.notify('\n'.join(_uniqueness_messages))
+
+# run over common string fields automatically
+def sanitize(string):
+  return string.replace("\xa0", " ").strip()
 
 def download_report(report):
   report_path = path_for(report, report['file_type'])

--- a/inspectors/utils/inspector.py
+++ b/inspectors/utils/inspector.py
@@ -123,7 +123,7 @@ def validate_report(report):
       return "Summary URL is not valid: %s" % report.get("summary_url")
 
   # report_id can't have slashes, it'll mess up the directory structure
-  for character in "/\\:*?\"<>|\r\n":
+  for character in str.join("", invalid_chars()):
     if character in report["report_id"]:
       return "Invalid %s in report_id - find another way: %r" % (character, report["report_id"])
 
@@ -207,6 +207,16 @@ def verify_uniqueness_finalize_summary():
 # run over common string fields automatically
 def sanitize(string):
   return string.replace("\xa0", " ").strip()
+
+# invalid to use in a report ID
+def invalid_chars():
+  return ('/', '\\', ':', '*', '?', '"', '<', '>', '|', '\r', '\n')
+
+# a scraper can use this to slugify a report_id
+def slugify(report_id):
+  copy = report_id
+  for char in invalid_chars():
+    copy = copy.replace(char, "-")
 
 def download_report(report):
   report_path = path_for(report, report['file_type'])

--- a/inspectors/utils/utils.py
+++ b/inspectors/utils/utils.py
@@ -17,7 +17,7 @@ from . import admin
 
 # ugh
 WHITELIST_INSECURE_DOMAINS = (
-  "https://www.ignet.gov"
+  "https://www.ignet.gov",
 )
 
 

--- a/safe.yml
+++ b/safe.yml
@@ -158,7 +158,7 @@
 - nrc
 
 # National Science Foundation
-# - nsf
+- nsf
 
 # Office of Personnel Management
 - opm

--- a/safe.yml
+++ b/safe.yml
@@ -120,8 +120,9 @@
 # House of Representatives
 - house
 
+# TODO: their website appears down.
 # Department of Housing and Urban Development
-- hud
+# - hud
 
 # Department of the Interior
 - interior


### PR DESCRIPTION
This catches up on a couple months of scrapers going to seed. Most of the fixes are small and scraper-specific, and I suggest just looking at the commits. 

But a few notes:

* All important report strings (e.g. `summary`, `title`) get unicode spaces replaced with normal spaces now.
* `www.ignet.gov` has misconfigured HTTPS, and so I've whitelisted it and provided a way to disable verification only to whitelisted domains.
* When doing the verification whitelist, I found a bug in scrapelib, [filed here](https://github.com/sunlightlabs/scrapelib/issues/31). When it's fixed, we can remove the direct `requests.get` call for non-binary downloads. I left the `scraperlib.urlretrieve` call in for binary downloads, rather than re-implement scrapelib's urlretrieve method, so we are currently absorbing a bug that disables future HTTPS verification for that run, after first encountering a `www.ignet.gov` URL.
* I moved some validation information out into individual `utils` methods (text sanitization, and report ID slugification), so that scrapers could use them as needed.
* I fixed `nsf` and added it back to `safe.yml`.
* I removed `hud` from `safe.yml`, as [their old website](http://www.hudoig.gov/) [appears down](http://www.downforeveryoneorjustme.com/www.hudoig.gov), and so does their [new one](http://portal.hud.gov/portal/page/portal/HUD/program_offices/oig).

I had my crontab off for the last couple months, as I'd left the archive in a weird state after doing all the Internet Archive work. My crontab's back on again, and I'd welcome the help of anyone else running this in production at keeping the scrapers on their toes. :smiley_cat: 