### PR TITLE
Partially resuscitate ITC OIG scraper

### DIFF
--- a/inspectors/itc.py
+++ b/inspectors/itc.py
@@ -18,14 +18,14 @@ archive = 1990
 # - There are some typos in report numbers and link URLS for audit reports
 #   between 1999 and 2001. See the comments in report_from() for details.
 
-AUDIT_REPORTS_URL = "http://www.usitc.gov/oig/audit_reports.htm"
+AUDIT_REPORTS_URL = "http://www.usitc.gov/oig/audit_reports.html"
 SEMIANNUAL_REPORTS_URL = "http://www.usitc.gov/oig/semiannual_reports.htm"
 PEER_REVIEWS_URL = "http://www.usitc.gov/oig/peer_reviews.htm"
 
 REPORT_URLS = {
   "audit": AUDIT_REPORTS_URL,
-  "semiannual_report": SEMIANNUAL_REPORTS_URL,
-  "peer_review": PEER_REVIEWS_URL,
+  # "semiannual_report": SEMIANNUAL_REPORTS_URL,
+  # "peer_review": PEER_REVIEWS_URL,
 }
 
 def run(options):
@@ -34,16 +34,26 @@ def run(options):
   # Pull the audit reports
   for report_type, url in REPORT_URLS.items():
     doc = BeautifulSoup(utils.download(url))
-    results = doc.select("div.text1 ul li")
-    for result in results:
-      report = report_from(result, url, report_type, year_range)
-      if report:
-        inspector.save_report(report)
+
+    headers = doc.select("p.Ptitle1")
+
+    for header in headers:
+      year = int(header.text.strip())
+      results = header.findNextSibling("ul").select("li")
+
+      for result in results:
+        if not inspector.sanitize(result.text):
+          logging.debug("Skipping empty list item.")
+          continue
+
+        report = report_from(year, result, url, report_type, year_range)
+        if report:
+          inspector.save_report(report)
 
 global flag_inspection_report_01_01
 flag_inspection_report_01_01 = False
 
-def report_from(result, landing_url, report_type, year_range):
+def report_from(year, result, landing_url, report_type, year_range):
   link = result.find("a", text=True)
   report_url = urljoin(landing_url, link.get('href'))
   report_id = "-".join(link.text.split()).replace(':', '')

--- a/inspectors/itc.py
+++ b/inspectors/itc.py
@@ -36,6 +36,8 @@ def run(options):
     doc = BeautifulSoup(utils.download(url))
 
     headers = doc.select("p.Ptitle1")
+    if not headers:
+      raise Exception("ITC scraper not working, no elements found.")
 
     for header in headers:
       year = int(header.text.strip())

--- a/inspectors/itc.py
+++ b/inspectors/itc.py
@@ -32,30 +32,29 @@ def run(options):
   year_range = inspector.year_range(options, archive)
 
   # Pull the audit reports
-  for report_type, url in REPORT_URLS.items():
-    doc = BeautifulSoup(utils.download(url))
+  doc = BeautifulSoup(utils.download(AUDIT_REPORTS_URL))
 
-    headers = doc.select("p.Ptitle1")
-    if not headers:
-      raise Exception("ITC scraper not working, no elements found.")
+  headers = doc.select("p.Ptitle1")
+  if not headers:
+    raise Exception("ITC scraper not working, no elements found.")
 
-    for header in headers:
-      year = int(header.text.strip())
-      results = header.findNextSibling("ul").select("li")
+  for header in headers:
+    year = int(header.text.strip())
+    results = header.findNextSibling("ul").select("li")
 
-      for result in results:
-        if not inspector.sanitize(result.text):
-          logging.debug("Skipping empty list item.")
-          continue
+    for result in results:
+      if not inspector.sanitize(result.text):
+        logging.debug("Skipping empty list item.")
+        continue
 
-        report = report_from(year, result, url, report_type, year_range)
-        if report:
-          inspector.save_report(report)
+      report = audit_report_from(year, result, AUDIT_REPORTS_URL, year_range)
+      if report:
+        inspector.save_report(report)
 
 global flag_inspection_report_01_01
 flag_inspection_report_01_01 = False
 
-def report_from(year, result, landing_url, report_type, year_range):
+def audit_report_from(year, result, landing_url, year_range):
   link = result.find("a", text=True)
   report_url = urljoin(landing_url, link.get('href'))
   report_id = "-".join(link.text.split()).replace(':', '')
@@ -125,7 +124,7 @@ def report_from(year, result, landing_url, report_type, year_range):
     'inspector_url': 'http://www.usitc.gov/oig/',
     'agency': 'itc',
     'agency_name': 'International Trade Commission',
-    'type': report_type,
+    'type': 'audit',
     'report_id': report_id,
     'url': report_url,
     'title': title,


### PR DESCRIPTION
The `itc` scraper had stopped getting anything at all, without any warnings or errors. I noticed this because the `itc` directory wasn't there at all in the new archive I made in November, so the scraper had already broken by then without warning.

This rewrites the scraper to handle Audit reports, but not for [Semiannual](http://usitc.gov/oig/semiannual_reports.htm) or [Peer Reviews](http://usitc.gov/oig/peer_reviews.htm). They shouldn't be hard to do. If anyone wants to hop in on this branch and finish the job, I'd much appreciate it.

I've also added a check at the top of the scraper that throws an exception if it finds 0 reports on the audits page. The scrapers should make a point to choke if unexpected behavior happens that suggests a too-graceful handling of changed markup.