### PR TITLE
new url for NRC semiannual reports

### DIFF
--- a/inspectors/nrc.py
+++ b/inspectors/nrc.py
@@ -20,7 +20,7 @@ archive = 1995
 # REPORT_PUBLISHED_MAPPING
 
 AUDITS_REPORTS_URL = "http://www.nrc.gov/reading-rm/doc-collections/insp-gen/{}/"
-SEMIANNUAL_REPORTS_URL = "http://www.nrc.gov/insp-gen/pubs.html"
+SEMIANNUAL_REPORTS_URL = "http://www.nrc.gov/reading-rm/doc-collections/nuregs/staff/sr1415/index.html"
 OTHER_REPORT_URLS = [
   ("http://www.nrc.gov/reading-rm/doc-collections/nuregs/brochures/br0304/",
    "NUREG-BR-0304-"),


### PR DESCRIPTION
References #200. NRC semiannual reports _are_ still in a table, but that table is now in a [different place](http://www.nrc.gov/reading-rm/doc-collections/nuregs/staff/sr1415/index.html). 