### PR TITLE
Fail hard if a scraper finds no reports

### DIFF
--- a/inspectors/agriculture.py
+++ b/inspectors/agriculture.py
@@ -126,6 +126,8 @@ def run(options):
     agency_url = urljoin(AGENCY_BASE_URL, agency_path)
     doc = beautifulsoup_from_url(agency_url)
     results = doc.select("ul li")
+    if not results:
+      raise inspector.NoReportsFoundError("Department of Agriculture (%s)" % agency_slug)
     for result in results:
       report = report_from(result, agency_url, year_range,
         report_type='audit', agency_slug=agency_slug)
@@ -145,6 +147,8 @@ def run(options):
   for report_type, url in OTHER_REPORT_TYPES.items():
     doc = beautifulsoup_from_url(url)
     results = doc.select("ul li")
+    if not results:
+      raise inspector.NoReportsFoundError("Department of Agriculture (other reports)")
     for result in results:
       report = report_from(result, url, year_range, report_type=report_type)
       if report:

--- a/inspectors/agriculture.py
+++ b/inspectors/agriculture.py
@@ -127,6 +127,9 @@ def run(options):
     doc = beautifulsoup_from_url(agency_url)
     results = doc.select("ul li")
     if not results:
+      results = [ancestor_tag_by_name(x, 'tr') for x in \
+        doc.select('img[src$="pdf-pic1.gif"]')]
+    if not results:
       raise inspector.NoReportsFoundError("Department of Agriculture (%s)" % agency_slug)
     for result in results:
       report = report_from(result, agency_url, year_range,
@@ -154,7 +157,11 @@ def run(options):
       if report:
         inspector.save_report(report)
 
+DATE_FORMATS = ['%m/%d/%Y', '%m/%Y']
+
 def report_from(result, page_url, year_range, report_type, agency_slug="agriculture"):
+  published_on = None
+
   try:
     # Try to find the link with text first. Sometimes there are hidden links
     # (no text) that we want to ignore.
@@ -163,15 +170,26 @@ def report_from(result, page_url, year_range, report_type, agency_slug="agricult
     link = result.find_all("a")[0]
   report_url = urljoin(page_url, link.get('href').strip())
 
-  title = link.text.strip()
-  if title.endswith("(PDF)"):
-    title = title[:-5]
-  if title.endswith("(PDF), (Report No: 30601-01-HY, Size: 847,872 bytes)"):
-    title = title[:-52]
-  title = title.rstrip(" ")
-  title = title.replace("..", ".")
-  title = title.replace("  ", " ")
-  title = title.replace("REcovery", "Recovery")
+  if result.name == 'li':
+    title = link.text.strip()
+    if title.endswith("(PDF)"):
+      title = title[:-5]
+    if title.endswith("(PDF), (Report No: 30601-01-HY, Size: 847,872 bytes)"):
+      title = title[:-52]
+    title = title.rstrip(" ")
+    title = title.replace("..", ".")
+    title = title.replace("  ", " ")
+    title = title.replace("REcovery", "Recovery")
+  elif result.name == 'tr':
+    published_on_element = result.strong.extract()
+    published_on_text = published_on_element.text.strip().rstrip(":")
+    for date_format in DATE_FORMATS:
+      try:
+        published_on = datetime.datetime.strptime(published_on_text, date_format)
+      except ValueError:
+        pass
+    title = result.text
+    title = title[:title.find('(')].strip()
 
   # These entries on the IG page have the wrong URLs associated with them. The
   # correct URLs were retrieved from an earlier version of the page, via the
@@ -207,20 +225,20 @@ def report_from(result, page_url, year_range, report_type, agency_slug="agricult
 
   if report_id in REPORT_PUBLISHED_MAPPING:
     published_on = REPORT_PUBLISHED_MAPPING[report_id]
-  else:
+  if not published_on:
     try:
       # This is for the investigation reports
       published_on = datetime.datetime.strptime(result.text.strip(), '%B %Y (PDF)')
       title = "Investigation Bulletins {}".format(result.text.strip())
     except ValueError:
-      published_on_text = result.text.split()[0].strip()
-
-      date_formats = ['%m/%d/%Y', '%m/%Y']
-      for date_format in date_formats:
-        try:
-          published_on = datetime.datetime.strptime(published_on_text, date_format)
-        except ValueError:
-          pass
+      pass
+  if not published_on:
+    published_on_text = result.text.split()[0].strip()
+    for date_format in DATE_FORMATS:
+      try:
+        published_on = datetime.datetime.strptime(published_on_text, date_format)
+      except ValueError:
+        pass
 
   if published_on.year not in year_range:
     logging.debug("[%s] Skipping, not in requested range." % report_url)
@@ -246,5 +264,10 @@ def beautifulsoup_from_url(url):
   body = utils.download(url)
   return BeautifulSoup(body)
 
+def ancestor_tag_by_name(element, name):
+  for parent in element.parents:
+    if parent.name == name:
+      return parent
+  return None
 
 utils.run(run) if (__name__ == "__main__") else None

--- a/inspectors/amtrak.py
+++ b/inspectors/amtrak.py
@@ -39,6 +39,8 @@ def run(options):
         done = True
 
       results = doc.select("table.views-table > tbody > tr")
+      if not results:
+        raise inspector.NoReportsFoundError("Amtrak")
       for result in results:
         report = report_from(result)
         inspector.save_report(report)

--- a/inspectors/arc.py
+++ b/inspectors/arc.py
@@ -34,6 +34,8 @@ def run(options):
   for report_type, url in REPORT_TYPES.items():
     doc = BeautifulSoup(utils.download(url))
     results = doc.select("table p > a")
+    if not results:
+      raise inspector.NoReportsFoundError("ARC (%s)" % report_type)
     for result in results:
       report = report_from(result, url, report_type, year_range)
       if report:

--- a/inspectors/archives.py
+++ b/inspectors/archives.py
@@ -32,6 +32,8 @@ def run(options):
     url = AUDIT_REPORTS_URL.format(year=year)
     doc = BeautifulSoup(utils.download(url))
     results = doc.select("div#content li")
+    if not results:
+      raise inspector.NoReportsFoundError("National Archives and Records Administration audit reports")
     for result in results:
       report = audit_report_from(result, url, year, year_range)
       if report:
@@ -40,6 +42,8 @@ def run(options):
   # Pull the semiannual reports
   doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
   results = doc.select("div#content li")
+  if not results:
+    raise inspector.NoReportsFoundError("National Archives and Records Administration semiannual reports")
   for result in results:
     report = semiannual_report_from(result, year_range)
     if report:

--- a/inspectors/cftc.py
+++ b/inspectors/cftc.py
@@ -33,6 +33,8 @@ def run(options):
   # Pull the audit reports
   doc = BeautifulSoup(utils.download(REPORTS_URL))
   results = doc.select("ul.text > ul > li")
+  if not results:
+    raise inspector.NoReportsFoundError("CFTC audit reports")
   for result in results:
     report = report_from(result, year_range)
     if report:
@@ -40,6 +42,8 @@ def run(options):
 
   # Pull the semiannual reports
   results = doc.select("ul.text td a")
+  if not results:
+    raise inspector.NoReportsFoundError("CFTC semiannual reports")
   for result in results:
     report = report_from(result, year_range, report_type="semiannual_report")
     if report:

--- a/inspectors/cncs.py
+++ b/inspectors/cncs.py
@@ -63,7 +63,7 @@ def run(options):
           if report:
             inspector.save_report(report)
       elif report_type != "case":
-        raise AssertionError("No report links found for %s" % url)
+        raise inspector.NoReportsFoundError("CNCS (%s)" % url)
       # closed cases have broken pagination (p6, 7, 8 missing) so ignore
       else:
         pass

--- a/inspectors/commerce.py
+++ b/inspectors/commerce.py
@@ -68,7 +68,10 @@ def extract_reports_for_topic(topic, year_range):
 
   topic_page = beautifulsoup_from_url(topic_url)
   results = topic_page.select("div.row")
-
+  if not results:
+    temp_text = topic_page.select("div.item")[0].text
+    if temp_text.find("No items available for ") == -1:
+      raise inspector.NoReportsFoundError("Department of Commerce (%s)" % topic)
   for result in results:
     report = report_from(result, topic, topic_url, year_range)
     if report:

--- a/inspectors/cpb.py
+++ b/inspectors/cpb.py
@@ -47,7 +47,7 @@ def run(options):
     doc = BeautifulSoup(utils.download(url))
     results = doc.select("div#content div#contentMain ul li.pdf")
     if not results:
-      raise AssertionError("No report links found for %s" % url)
+      raise inspector.NoReportsFoundError("CPB (%s)" % url)
     for result in results:
       if not result.find('a'):
         # Skip unlinked PDF's

--- a/inspectors/cpsc.py
+++ b/inspectors/cpsc.py
@@ -29,6 +29,8 @@ def run(options):
 
   doc = BeautifulSoup(utils.download(REPORTS_URL))
   results = doc.select("ul.summary-list li")
+  if not results:
+    raise inspector.NoReportsFoundError("CPSC")
   for result in results:
     report = report_from(result, year_range)
     if report:

--- a/inspectors/denali.py
+++ b/inspectors/denali.py
@@ -72,6 +72,8 @@ def run(options):
 
   doc = BeautifulSoup(utils.download(REPORTS_URL))
   results = doc.select("#mainContent blockquote a")
+  if not results:
+    raise inspector.NoReportsFoundError("Denali Commission")
   for result in results:
     report = report_from(result, year_range)
     if report:

--- a/inspectors/dhs.py
+++ b/inspectors/dhs.py
@@ -42,6 +42,8 @@ def run(options):
     # accept only trs that look like body tr's (no 'align' attribute)
     #   note: HTML is very inconsistent. cannot rely on thead or tbody
     results = [x for x in results if x.get('align') is None]
+    if not results:
+      raise inspector.NoReportsFoundError("DHS (%s)" % component)
 
     count = 0
     for result in results:

--- a/inspectors/doj.py
+++ b/inspectors/doj.py
@@ -495,6 +495,8 @@ def get_content(url):
   page = utils.download(url)
   page = BeautifulSoup(page)
   content = page.select(".content-left")
+  if not content:
+    raise inspector.NoReportsFoundError("DOJ (%s)" % url)
   return content
 
 

--- a/inspectors/dot.py
+++ b/inspectors/dot.py
@@ -80,8 +80,11 @@ def run(options):
       body = utils.download(year_url)
 
       doc = BeautifulSoup(body)
-      results = doc.select(".view-business-areas .views-row")
 
+      if not doc.select(".view-business-areas"):
+        raise inspector.NoReportsFoundError("DOT (%s)" % topic)
+
+      results = doc.select(".view-business-areas .views-row")
       for result in results:
         report = report_from(result, year_range, topic, options)
         if report:

--- a/inspectors/eac.py
+++ b/inspectors/eac.py
@@ -42,7 +42,7 @@ def run(options):
     doc = BeautifulSoup(utils.download(url))
     results = doc.select("div.mainRegion p a")
     if not results:
-      raise AssertionError("No report links found for %s" % url)
+      raise inspector.NoReportsFoundError("EAC (%s)" % url)
     for result in results:
       report = report_from(result, url, report_type, year_range)
       if report:

--- a/inspectors/education.py
+++ b/inspectors/education.py
@@ -70,6 +70,8 @@ def run(options):
     url = audit_url_for(year)
     doc = beautifulsoup_from_url(url)
     agency_tables = doc.find_all("table", {"border": 1})
+    if not agency_tables:
+      raise inspector.NoReportsFoundException("Department of Education (%d audit reports)" % year)
     for agency_table in agency_tables:
       results = agency_table.select("tr")
       for index, result in enumerate(results):
@@ -102,6 +104,8 @@ def run(options):
   for report_type, url in OTHER_REPORTS_URL.items():
     doc = beautifulsoup_from_url(url)
     results = doc.select("div.contentText ul li")
+    if not results:
+      raise inspector.NoReportsFoundException("Department of Education (%s)" % report_type)
     for result in results:
       report = report_from(result, url, report_type, year_range)
       if report:

--- a/inspectors/eeoc.py
+++ b/inspectors/eeoc.py
@@ -33,6 +33,12 @@ def run(options):
   # Pull the reports
   doc = BeautifulSoup(utils.download(REPORTS_URL))
   semiannual_report_results, other_results = doc.select("table tr")[1].select("td")
+
+  if not semiannual_report_results:
+    raise inspector.NoReportsFoundException("EEOC (semiannual reports)")
+  if not other_results:
+    raise inspector.NoReportsFoundException("EEOC (other reports)")
+
   merge_items(semiannual_report_results)
   merge_items(other_results)
 

--- a/inspectors/energy.py
+++ b/inspectors/energy.py
@@ -110,6 +110,8 @@ class EnergyScraper(object):
         nodes = page.select('.field-items .node')
       if not nodes:
         nodes = page.select('.node')
+      if not nodes:
+        raise inspector.NoReportsFoundException("Department of Energy (%s)" % url)
 
       for node in nodes:
         report = self.report_from(node)

--- a/inspectors/epa.py
+++ b/inspectors/epa.py
@@ -64,6 +64,8 @@ def run(options):
   current_year = None
   index = BeautifulSoup(index_body)
   tables = index.select('table.style1')
+  if not tables:
+    raise inspector.NoReportsFoundException("EPA")
   for table in tables:
     trs = table.select('tr')
     for tr in trs:

--- a/inspectors/exim.py
+++ b/inspectors/exim.py
@@ -18,7 +18,8 @@ def run(options):
 
     maincontent = doc.select("div#CS_Element_eximpagemaincontent")[0]
     all_a = maincontent.find_all("a")
-
+    if not all_a:
+      raise inspector.NoReportsFoundException("Ex-Im Bank (%s)" % page_url)
     for a in all_a:
       a_text = str(a.text)
       if a_text.strip() == "":

--- a/inspectors/fca.py
+++ b/inspectors/fca.py
@@ -32,6 +32,8 @@ def run(options):
   # Pull the general reports
   doc = BeautifulSoup(utils.download(REPORTS_URL))
   results = doc.select("div#mainContent li.mainContenttext a")
+  if not results:
+    raise inspector.NoReportsFoundError("Farm Credit Administration (reports)")
   for result in results:
     report = report_from(result, REPORTS_URL, year_range)
     if report:
@@ -40,6 +42,8 @@ def run(options):
   # Pull the archive reports
   doc = BeautifulSoup(utils.download(REPORT_ARCHIVE_URL))
   results = doc.select("div#mainContent li.mainContenttext a") + doc.select("div#mainContent span.mainContenttext a")
+  if not results:
+    raise inspector.NoReportsFoundError("Farm Credit Administration (archive)")
   for result in results:
     if not result.text:
       continue
@@ -50,6 +54,8 @@ def run(options):
   # Pull the semiannual reports
   doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
   results = doc.select("div#mainContent li.mainContenttext a")
+  if not results:
+    raise inspector.NoReportsFoundError("Farm Credit Administration (semiannual reports)")
   for result in results:
     report = semiannual_report_from(result, year_range)
     if report:

--- a/inspectors/fcc.py
+++ b/inspectors/fcc.py
@@ -32,6 +32,8 @@ def run(options):
   for report_type, url in REPORT_URLS.items():
     doc = beautifulsoup_from_url(url)
     results = doc.find_all("table", {"border": 2})[0].select("tr")
+    if not results:
+      raise inspector.NoReportsFoundError("FCC (%s)" % report_type)
     for index, result in enumerate(results):
       if index < 2:
         # The first two rows are headers

--- a/inspectors/fdic.py
+++ b/inspectors/fdic.py
@@ -34,6 +34,8 @@ def run(options):
   # Pull the reports
   doc = BeautifulSoup(utils.download(REPORTS_URL))
   results = doc.find("table", {"cellpadding": "5"}).select("tr")
+  if not results:
+    raise inspector.NoReportsFoundError("FDIC")
   for index, result in enumerate(results):
     if index < 3 or not result.text.strip():
       # The first three rows are headers

--- a/inspectors/fec.py
+++ b/inspectors/fec.py
@@ -54,7 +54,8 @@ def run(options):
   # They have two separate uls for these reports. See note to the IG web team.
   audit_list2 = audit_header.find_next("ul").find_next("ul").select("li")
   results = audit_list1 + audit_list2
-
+  if not results:
+    raise inspector.NoReportsFoundError("FEC (audit reports)")
   for result in results:
     report = report_from(result, year_range, report_type='audit')
     if report:
@@ -63,7 +64,8 @@ def run(options):
   # Pull the inspection reports
   inspections_header = doc.find("a", attrs={"name": 'Inspection Reports'})
   results = inspections_header.find_next("ul").select("li")
-
+  if not results:
+    raise inspector.NoReportsFoundError("FEC (inspection reports)")
   for result in results:
     report = report_from(result, year_range, report_type='inspection')
     if report:
@@ -72,7 +74,8 @@ def run(options):
   # Pull the semiannual reports
   semiannual_header = doc.find("a", attrs={"name": 'Semiannual Reports'})
   results = semiannual_header.find_next("ul").select("li")
-
+  if not results:
+    raise inspector.NoReportsFoundError("FEC (semiannual reports)")
   for result in results:
     report = report_from(result, year_range, report_type='semiannual_report', title_prefix="Semiannual Report - ")
     if report:

--- a/inspectors/fed.py
+++ b/inspectors/fed.py
@@ -51,6 +51,8 @@ def run(options):
   # Pull the audit reports
   doc = beautifulsoup_from_url(REPORTS_URL)
   results = doc.select("#rounded-corner > tr")
+  if not results:
+    raise inspector.NoReportsFoundError("Federal Reserve (audit reports)")
   for result in results:
     report = report_from(result, year_range)
     if report:
@@ -59,6 +61,8 @@ def run(options):
   # Pull the semiannual reports
   doc = beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
   results = doc.select("div.style-aside ul > li > a")
+  if not results:
+    raise inspector.NoReportsFoundError("Federal Reserve (semiannual reports)")
   for result in results:
     report_url = urljoin(BASE_PAGE_URL, result.get('href'))
     report = semiannual_report_from(report_url, year_range)

--- a/inspectors/fhfa.py
+++ b/inspectors/fhfa.py
@@ -42,8 +42,11 @@ def run(options):
     doc = BeautifulSoup(utils.download(AUDIT_REPORTS_URL.format(page=page)))
     results = doc.select("span.field-content")
     if not results:
-      # No more results, we must have hit the last page
-      break
+      if page == 0:
+        raise inspector.NoReportsFound("FHFA (audit reports)")
+      else:
+        # No more results, we must have hit the last page
+        break
 
     for result in results:
       report = report_from(result, year_range, report_type='audit')
@@ -56,6 +59,8 @@ def run(options):
     results = doc.select(".views-field")
     if not results:
       results = doc.select(".views-row")
+    if not results:
+      raise inspector.NoReportsFound("FHFA (%s)" % report_type)
     for result in results:
       report = report_from(result, year_range, report_type)
       if report:

--- a/inspectors/flra.py
+++ b/inspectors/flra.py
@@ -38,6 +38,8 @@ def run(options):
   for report_type, url in REPORT_URLS.items():
     doc = BeautifulSoup(utils.download(url))
     results = doc.select("div.node ul li")
+    if not results:
+      raise inspector.NoReportsFoundError("Federal Labor Relations Authority (%s)" % report_type)
     for result in results:
       report = report_from(result, url, report_type, year_range)
       if report:

--- a/inspectors/fmc.py
+++ b/inspectors/fmc.py
@@ -46,6 +46,8 @@ def run(options):
   # Pull the audit reports
   doc = BeautifulSoup(utils.download(AUDIT_REPORTS_URL))
   results = doc.select("table tr")
+  if not results:
+    raise inspector.NoReportsFoundError("Federal Maritime Commission (audits)")
   for index, result in enumerate(results):
     if not index:
       # Skip the header row
@@ -64,7 +66,7 @@ def run(options):
       # Grab results other than first and last (header and extra links)
       results = doc.select("div.col-2-2 ul")[1:-1]
     if not results:
-      raise AssertionError("No report links found for %s" % audit_year_url)
+      raise inspector.NoReportsFoundError("Federal Maritime Commission (%s)" % audit_year_url)
     for index, result in enumerate(results):
       if not index:
         # Skip the header row
@@ -76,6 +78,8 @@ def run(options):
   # Pull the semiannual reports
   doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
   results = doc.select("div.col-2-2 p a") + doc.select("div.col-2-2 li a")
+  if not results:
+    raise inspector.NoReportsFoundError("Federal Maritime Commission (semiannual reports)")
   for result in results:
     report = report_from(result.parent, AUDIT_REPORTS_URL, report_type='semiannual_report', year_range=year_range)
     if report:

--- a/inspectors/ftc.py
+++ b/inspectors/ftc.py
@@ -33,6 +33,8 @@ def run(options):
   for report_type, url in REPORT_URLS.items():
     doc = BeautifulSoup(utils.download(url))
     results = doc.select("li.views-row")
+    if not results:
+      raise inspector.NoReportsFoundError("FTC (%s)" % report_type)
     for result in results:
       report = report_from(result, url, report_type, year_range)
       if report:

--- a/inspectors/gao.py
+++ b/inspectors/gao.py
@@ -27,6 +27,8 @@ def run(options):
   for reports_url in [REPORTS_URL, SEMIANNUAL_REPORTS_URL]:
     doc = beautifulsoup_from_url(reports_url)
     results = doc.select("div.listing")
+    if not results:
+      raise inspector.NoReportsFoundError("GAO (%s)" % reports_url)
     for result in results:
       report = report_from(result, year_range)
       if report:

--- a/inspectors/gpo.py
+++ b/inspectors/gpo.py
@@ -39,7 +39,7 @@ def run(options):
     if not results:
       results = doc.select("td.three-col-layout-middle div.ltext > table tr")
     if not results:
-      raise AssertionError("No report links found for %s" % url)
+      raise inspector.NoReportsFoundError("Government Printing Office (%s)" % url)
     for result in results:
       if (not result.text.strip() or
           result.find("th") or

--- a/inspectors/gsa.py
+++ b/inspectors/gsa.py
@@ -43,6 +43,10 @@ def crawl_index(base_url, options, is_meta_index=False):
       done = True
 
     results = doc.select("div#svPortal dl")
+    if not results and page == 1:
+      temp_text = doc.select("div#svPortal")[0].text.strip()
+      if temp_text != "There is currently no content available.":
+        raise inspector.NoReportsFoundError("Government Services Administration (%s)" % url)
     for result in results:
       if "moreResults" in result.get("class"):
         continue

--- a/inspectors/hhs.py
+++ b/inspectors/hhs.py
@@ -226,6 +226,8 @@ def extract_reports_for_subtopic(subtopic_url, year_range, topic_name, subtopic_
     results = doc.select("#leftContentInterior ul li")
   if not results:
     results = doc.select("#leftContentInterior > p > a")
+  if not results:
+    raise inspector.NoReportsFoundError("HHS (%s)" % subtopic_name)
   for result in results:
     if 'crossref' in result.parent.parent.attrs.get('class', []):
       continue
@@ -247,6 +249,9 @@ def extract_reports_for_oei(year_range):
     absolute_url = strip_url_fragment(absolute_url)
     letter_urls.add(absolute_url)
 
+  if not letter_urls:
+    raise inspector.NoReportsFoundError("HHS (OEI first pass)")
+
   all_results_links = {}
   all_results_unreleased = []
   for letter_url in letter_urls:
@@ -254,6 +259,8 @@ def extract_reports_for_oei(year_range):
     letter_doc = BeautifulSoup(letter_body)
 
     results = letter_doc.select("#leftContentInterior ul li")
+    if not results:
+      raise inspector.NoReportsFoundError("HHS (OEI %s)" % letter_url)
     for result in results:
       if 'crossref' in result.parent.parent.attrs.get('class', []):
         continue
@@ -515,6 +522,9 @@ def get_subtopic_map(topic_url):
     # Only add new URLs
     if absolute_url not in subtopic_map.values():
       subtopic_map[link.text] = absolute_url
+
+  if not subtopic_map:
+    raise inspector.NoReportsFoundError("OEI (subtopics)")
 
   return subtopic_map
 

--- a/inspectors/house.py
+++ b/inspectors/house.py
@@ -43,7 +43,7 @@ def run(options):
     doc = BeautifulSoup(utils.download(url))
     results = doc.select("div.relatedContent ul.links li a")
     if not results:
-      raise AssertionError("No report links found for %s" % url)
+      raise inspector.NoReportsFoundError("House of Representatives (%s)" % url)
     for result in results:
       report = report_from(result, url, year_range)
       if report:

--- a/inspectors/hud.py
+++ b/inspectors/hud.py
@@ -134,9 +134,12 @@ def run(options):
 
     rows = index.select('div.views-row')
 
-    # If no more reports found, quit
     if not rows:
-      break
+      if page == 1:
+        raise inspector.NoReportsFoundError("HUD (url)")
+      else:
+        # If no more reports found, quit
+        break
 
     for row in rows:
       report = report_from(row, year_range)

--- a/inspectors/interior.py
+++ b/inspectors/interior.py
@@ -40,6 +40,8 @@ def run(options):
   doc = BeautifulSoup(response)
 
   results = doc.select("div.report")
+  if not results:
+    raise inspector.NoReportsFoundError("Department of the Interior")
   for result in results:
     report = report_from(result, year_range)
     if report:

--- a/inspectors/itc.py
+++ b/inspectors/itc.py
@@ -36,7 +36,7 @@ def run(options):
 
   headers = doc.select("p.Ptitle1")
   if not headers:
-    raise Exception("ITC scraper not working, no elements found.")
+    raise inspector.NoReportsFoundError("ITC")
 
   for header in headers:
     year = int(header.text.strip())

--- a/inspectors/labor.py
+++ b/inspectors/labor.py
@@ -47,7 +47,10 @@ def run(options):
       doc = beautifulsoup_from_url(year_url)
       results = doc.select("ol li")
       if not results:
-        break
+        if page_number == 0:
+          raise inspector.NoReportsFoundError("Department of Labor (%s)" % year_url)
+        else:
+          break
       for result in results:
         report = report_from(result, year_url)
         if report:
@@ -56,6 +59,8 @@ def run(options):
   # Pull the semiannual reports
   doc = beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
   results = doc.select("p > a:nth-of-type(1)")
+  if not results:
+    raise inspector.NoReportsFoundError("Department of Labor (semiannal reports)")
   for result in results:
     report = semiannual_report_from(result, year_range)
     if report:

--- a/inspectors/loc.py
+++ b/inspectors/loc.py
@@ -99,13 +99,19 @@ class LibraryOfCongressScraper(object):
   def get_listed_reports(self, url):
     doc = BeautifulSoup(utils.download(url))
     article = doc.select('.article')[0]
-    for ul in article.find_all('ul'):
+    results = article.find_all('ul')
+    if not results:
+      raise inspector.NoReportsFoundError("Library of Congress (%s)" % url)
+    for ul in results:
       self.get_bare_reports(ul)
 
   def get_semiannual_reports_to_congress(self, doc):
     header = doc.find_all(text=re.compile('Semiannual Reports'))
     ul = header[0].parent.find_next_sibling()
-    for li in ul.find_all('li'):
+    results = ul.find_all('li')
+    if not results:
+      raise inspector.NoReportsFoundError("Library of Congress (semiannual reports)")
+    for li in results:
       link = li.find('a')
       report_url = urljoin(REPORTS_BY_YEAR_URL, link['href'])
       report_id = report_url.split('/')[-1].split('.')[0]

--- a/inspectors/lsc.py
+++ b/inspectors/lsc.py
@@ -50,7 +50,13 @@ def run(options):
 
   # Pull the audit reports
   for url, report_type in REPORT_URLS.items():
-    doc = BeautifulSoup(utils.download(url))
+    page_content = utils.download(url)
+
+    # This typo confuses BS4 and interferes with our selectors
+    page_content = page_content.replace('<h4>2015</h3>', '<h4>2015</h4>')
+
+    doc = BeautifulSoup(page_content)
+
     results = doc.select("blockquote > ul > a")
     if not results:
       results = doc.select("blockquote > ul > li > a")

--- a/inspectors/lsc.py
+++ b/inspectors/lsc.py
@@ -58,6 +58,8 @@ def run(options):
       results = doc.select("blockquote > font > ul > a")
     if not results:
       results = doc.select("blockquote > a")
+    if not results:
+      raise inspector.NoReportsFoundError("Legal Services Corporation (%s)" % url)
     for result in results:
       report = report_from(result, url, report_type, year_range)
       if report:

--- a/inspectors/nasa.py
+++ b/inspectors/nasa.py
@@ -31,6 +31,8 @@ def run(options):
     url = AUDITS_REPORTS_URL.format(str(year)[2:4])
     doc = BeautifulSoup(utils.download(url))
     results = doc.select("tr")
+    if not results:
+      raise inspector.NoReportsFoundError("NASA (%d)" % year)
     for index, result in enumerate(results):
       if not index or not result.text.strip():
         # Skip the header row and any empty rows
@@ -42,6 +44,8 @@ def run(options):
   # Pull the other reports
   doc = BeautifulSoup(utils.download(OTHER_REPORT_URL))
   results = doc.select("#subContainer ul li")
+  if not results:
+    raise inspector.NoReportsFoundError("NASA (other)")
   for result in results:
     report = other_report_from(result, year_range)
     if report:

--- a/inspectors/ncua.py
+++ b/inspectors/ncua.py
@@ -36,6 +36,8 @@ def run(options):
       continue
 
     results = doc.select("div.content table tr")
+    if not results:
+      raise inspector.NoReportsFoundError("NCUA (%d)" % year)
     for index, result in enumerate(results):
       if not index:
         # Skip the header row
@@ -47,6 +49,8 @@ def run(options):
   # Pull the FOIA reports
   doc = BeautifulSoup(utils.download(FOIA_REPORTS_URL))
   results = doc.select("div.content table tr")
+  if not results:
+    raise inspector.NoReportsFoundError("NCUA (FOIA)")
   for index, result in enumerate(results):
     if not index:
       # Skip the header row
@@ -58,6 +62,8 @@ def run(options):
   # Pull the semiannual reports
   doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
   results = doc.select("div.content a")
+  if not results:
+    raise inspector.NoReportsFoundError("NCUA (semiannual reports)")
   for result in results:
     report = semiannual_report_from(result, year_range)
     if report:

--- a/inspectors/nea.py
+++ b/inspectors/nea.py
@@ -45,6 +45,8 @@ def run(options):
     doc = BeautifulSoup(utils.download(url))
     results = doc.select("div.field-item li")
     if not results:
+      results = doc.select("div.field-item tr")
+    if not results:
       raise inspector.NoReportsFoundError("National Endowment for the Arts (%s)" % report_type)
     for result in results:
       report = report_from(result, url, report_type, year_range)
@@ -75,7 +77,10 @@ def report_from(result, landing_url, report_type, year_range):
     try:
       published_on_year = int(result.find_previous("h3").text.strip())
     except AttributeError:
-      published_on_year = int(re.search('(\d+)', title).group())
+      try:
+        published_on_year = int(result.find_previous("strong").text.strip())
+      except AttributeError:
+        published_on_year = int(re.search('(\d+)', title).group())
     published_on = datetime.datetime(published_on_year, 11, 1)
     estimated_date = True
 

--- a/inspectors/nea.py
+++ b/inspectors/nea.py
@@ -44,6 +44,8 @@ def run(options):
   for report_type, url in REPORT_URLS.items():
     doc = BeautifulSoup(utils.download(url))
     results = doc.select("div.field-item li")
+    if not results:
+      raise inspector.NoReportsFoundError("National Endowment for the Arts (%s)" % report_type)
     for result in results:
       report = report_from(result, url, report_type, year_range)
 

--- a/inspectors/neh.py
+++ b/inspectors/neh.py
@@ -26,6 +26,8 @@ def run(options):
   # Pull the audit reports
   doc = BeautifulSoup(utils.download(AUDIT_REPORTS_URL))
   results = doc.select("table.views-table tr")
+  if not results:
+    raise inspector.NoReportsFoundError("National Endowment for the Humanities (audit reports)")
   for result in results:
     report = audit_report_from(result, year_range)
     if report:
@@ -34,6 +36,8 @@ def run(options):
   # Pull the semiannual reports
   doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
   results = doc.select("table.views-table tr")
+  if not results:
+    raise inspector.NoReportsFoundError("National Endowment for the Humanities (semiannual reports)")
   for result in results:
     report = semiannual_report_from(result, year_range)
     if report:

--- a/inspectors/nlrb.py
+++ b/inspectors/nlrb.py
@@ -39,6 +39,8 @@ def run(options):
   for report_type, reports_url in REPORT_URLS.items():
     doc = BeautifulSoup(utils.download(reports_url))
     results = doc.select("div.field-item")
+    if not results:
+      raise inspector.NoReportsFoundError("National Labor Relations Board (%s)" % report_type)
     for result in results:
       report = report_from(result, report_type, year_range)
       if report:
@@ -47,6 +49,8 @@ def run(options):
   # Pull the semiannual reports
   doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
   results = doc.select("div.field-item")
+  if not results:
+    raise inspector.NoReportsFoundError("National Labor Relations Board (semiannual reports)")
   for result in results:
     report = semiannual_report_from(result, year_range)
     if report:

--- a/inspectors/nrc.py
+++ b/inspectors/nrc.py
@@ -53,6 +53,8 @@ def run(options):
     url = AUDITS_REPORTS_URL.format(year)
     doc = BeautifulSoup(utils.download(url))
     results = doc.find("table", border="1").select("tr")
+    if not results:
+      raise inspector.NoReportsFoundError("Nuclear Regulatory Commission (%d)" % year)
     for index, result in enumerate(results):
       if not index:
         # Skip the header row
@@ -64,7 +66,10 @@ def run(options):
   # Pull the congressional testimony
   doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
   semiannual_reports_table = doc.find("table", border="1")
-  for index, result in enumerate(semiannual_reports_table.select("tr")):
+  results = semiannual_reports_table.select("tr")
+  if not results:
+    raise inspector.NoReportsFoundError("Nuclear Regulatory Commission (congressional testimony)")
+  for index, result in enumerate(results):
     if index < 2:
       # Skip the first two header rows
       continue
@@ -76,6 +81,8 @@ def run(options):
   for reports_url, id_prefix in OTHER_REPORT_URLS:
     doc = BeautifulSoup(utils.download(reports_url))
     results = doc.find("table", border="1").select("tr")
+    if not results:
+      raise inspector.NoReportsFoundError("Nuclear Regulatory Commission (other)")
     for index, result in enumerate(results):
       if not index:
         # Skip the header row

--- a/inspectors/nsf.py
+++ b/inspectors/nsf.py
@@ -45,6 +45,8 @@ def run(options):
   # Pull the audit reports
   doc = BeautifulSoup(utils.download(AUDIT_REPORTS_URL))
   results = doc.select("td.text table tr")
+  if not results:
+    raise inspector.NoReportsFoundError("National Science Foundation (audit reports")
   for result in results:
     # ignore divider lines
     if result.select("img"): continue
@@ -56,6 +58,8 @@ def run(options):
   # Pull the semiannual reports
   doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
   results = doc.select("td.text table tr")
+  if not results:
+    raise inspector.NoReportsFoundError("National Science Foundation (semiannual reports)")
   for result in results:
     if not result.text.strip():
       continue
@@ -70,6 +74,8 @@ def run(options):
   )
   doc = BeautifulSoup(response.content)
   results = doc.select("td.text table tr")
+  if not results:
+    raise inspector.NoReportsFoundError("National Science Foundation (case reports)")
   for index, result in enumerate(results):
     if not index or not result.text.strip():  # Skip the header row and empty rows
       continue
@@ -80,6 +86,8 @@ def run(options):
   # Pull the testimony
   doc = BeautifulSoup(utils.download(TESTIMONY_REPORTS_URL))
   results = doc.select("td.text table tr")
+  if not results:
+    raise inspector.NoReportsFoundError("National Science Foundation (testimony)")
   for result in results:
     if not result.text.strip():
       continue

--- a/inspectors/opm.py
+++ b/inspectors/opm.py
@@ -36,7 +36,8 @@ def run(options):
 
   doc = BeautifulSoup(body)
   results = doc.select("section")
-
+  if not results:
+    raise inspector.NoReportsFoundError("OPM")
   for result in results:
     try:
       year = int(result.get("title"))

--- a/inspectors/pbgc.py
+++ b/inspectors/pbgc.py
@@ -42,6 +42,8 @@ def run(options):
     year_url = AUDIT_REPORTS_URL.format(year=year)
     doc = BeautifulSoup(utils.download(year_url))
     results = doc.select("tr")
+    if not results:
+      raise inspector.NoReportsFoundError("Pension Benefit Guaranty Corporation (audit reports)")
     for result in results:
       report = report_from(result, report_type='audit', year_range=year_range)
       if report:
@@ -50,6 +52,8 @@ def run(options):
   # Pull the congressional requests
   doc = BeautifulSoup(utils.download(CONGRESSIONAL_REQUESTS_URL))
   results = doc.select("tr")
+  if not results:
+    raise inspector.NoReportsFoundError("Pension Benefit Guaranty Corporation (congressional requests)")
   for result in results:
     report = report_from(result, report_type='congress', year_range=year_range)
     if report:
@@ -58,6 +62,8 @@ def run(options):
   # Pull the semiannual reports
   doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
   results =  doc.select("div.holder a")
+  if not results:
+    raise inspector.NoReportsFoundError("Pension Benefit Guaranty Corporation (semiannual reports)")
   for result in results:
     report = semiannual_report_from(result, year_range)
     if report:
@@ -66,6 +72,8 @@ def run(options):
   # Pull the congressional testimony
   doc = BeautifulSoup(utils.download(CONGRESSIONAL_TESTIMONY_URL))
   results =  doc.select("div.holder a")
+  if not results:
+    raise inspector.NoReportsFoundError("Pension Benefit Guaranty Corporation (congressional testimony)")
   for result in results:
     report = testimony_report_from(result, year_range)
     if report:

--- a/inspectors/peacecorps.py
+++ b/inspectors/peacecorps.py
@@ -53,6 +53,8 @@ def run(options):
   # Pull the reports
   doc = BeautifulSoup(utils.download(REPORTS_URL))
   results = doc.select("li div li")
+  if not results:
+    raise inspector.NoReportsFoundError("Peace Corps")
   for result in results:
     report = report_from(result, year_range)
     if report:

--- a/inspectors/prc.py
+++ b/inspectors/prc.py
@@ -29,7 +29,10 @@ def run(options):
     doc = BeautifulSoup(response)
     results = doc.select(".reports")
     if not results:
-      break
+      if page == 0:
+        raise inspector.NoReportsFoundError("Postal Regulatory Commission")
+      else:
+        break
     for index, result in enumerate(results):
       report = report_from(result, year_range)
       if report:

--- a/inspectors/rrb.py
+++ b/inspectors/rrb.py
@@ -48,7 +48,10 @@ def run(options):
       continue
     year_url = AUDIT_REPORTS_URL.format(year=year)
     doc = BeautifulSoup(utils.download(year_url))
-    for index, result in enumerate(doc.select("#main table tr")):
+    results = doc.select("#main table tr")
+    if not results:
+      raise inspector.NoReportsFoundError("Railroad Retirement Board (%d)" % year)
+    for index, result in enumerate(results):
       if not index:
         # Skip the header row
         continue

--- a/inspectors/sba.py
+++ b/inspectors/sba.py
@@ -63,7 +63,10 @@ def run(options):
     doc = BeautifulSoup(page_html)
     results = doc.select("tr")
     if not results:
-      break
+      if page == 1:
+        raise inspector.NoReportsFoundError("Small Business Admininstration")
+      else:
+        break
 
     for index, result in enumerate(results):
       if not index:

--- a/inspectors/sec.py
+++ b/inspectors/sec.py
@@ -175,6 +175,8 @@ def run(options):
         results = [x for x in all_results.select("ul li")]
       except IndexError:
         results = doc.select("table ul li")
+    if not results:
+      raise inspector.NoReportsFoundError("SEC (%s)" % topic)
 
     # Sometimes multiple reports are listed under the same datetime element.
     # We store which published datetime we saw last so that the next report

--- a/inspectors/sigar.py
+++ b/inspectors/sigar.py
@@ -42,6 +42,8 @@ def run(options):
   for report_type, report_url in REPORT_URLS.items():
     doc = BeautifulSoup(utils.download(report_url))
     results = doc.select("item")
+    if not results:
+      raise inspector.NoReportsFoundError("SIGAR (%s)" % report_type)
     for result in results:
       report = report_from(result, report_url, report_type, year_range)
       if report:

--- a/inspectors/sigtarp.py
+++ b/inspectors/sigtarp.py
@@ -32,7 +32,7 @@ def run(options):
     results =  doc.select("td.mainInner div.ms-WPBody li")
 
     if not results:
-      raise AssertionError("No results found for {}".format(report_url))
+      raise inspector.NoReportsFoundError("SIGTARP (%s)" % report_url)
 
     for result in results:
       report = report_from(result, report_type, year_range)

--- a/inspectors/smithsonian.py
+++ b/inspectors/smithsonian.py
@@ -43,6 +43,8 @@ def run(options):
   # # Pull the RSS feed
   doc = BeautifulSoup(utils.download(RSS_URL))
   results = doc.select("item")
+  if not results:
+    raise inspector.NoReportsFoundError("Smithsonian (RSS)")
   for result in results:
     report = rss_report_from(result, year_range)
     if report:
@@ -51,6 +53,8 @@ def run(options):
   # # Pull the recent audit reports.
   doc = BeautifulSoup(utils.download(RECENT_AUDITS_URL))
   results = doc.select("div.block > a")
+  if not results:
+    raise inspector.NoReportsFoundError("Smithsonian (recent audit reports)")
   for result in results:
     report = report_from(result, year_range)
     if report:
@@ -59,6 +63,8 @@ def run(options):
   # Pull the archive audit reports
   doc = BeautifulSoup(utils.download(AUDIT_ARCHIVE_URL))
   results = doc.select("div.block a")
+  if not results:
+    raise inspector.NoReportsFoundError("Smithsonian (audit archive)")
   for result in results:
     report = report_from(result, year_range)
     if report:
@@ -67,6 +73,8 @@ def run(options):
   # Pull the other reports
   doc = BeautifulSoup(utils.download(OTHER_REPORTS_URl))
   results = doc.select("div.block > a")
+  if not results:
+    raise inspector.NoReportsFoundError("Smithsonian (other)")
   for result in results:
     report = report_from(result, year_range)
     if report:

--- a/inspectors/ssa.py
+++ b/inspectors/ssa.py
@@ -46,14 +46,20 @@ def run(options):
     for page in range(0, ALL_PAGES):
       reports_found = reports_from_page(AUDIT_REPORTS_URL, page, report_type, year_range, year)
       if not reports_found:
-        break
+        if page == 0:
+          raise inspector.NoReportsFoundError("Social Security Administration (%d)" % year)
+        else:
+          break
 
   # Pull the other reports
   for report_type, report_format in OTHER_REPORT_URLS.items():
     for page in range(0, ALL_PAGES):
       reports_found = reports_from_page(report_format, page, report_type, year_range)
       if not reports_found:
-        break
+        if page == 0:
+          raise inspector.NoReportsFoundError("Social Security Administration (%s)" % report_type)
+        else:
+          break
 
 def reports_from_page(url_format, page, report_type, year_range, year=''):
   url = url_format.format(page=page, year=year)

--- a/inspectors/state.py
+++ b/inspectors/state.py
@@ -58,7 +58,7 @@ def extract_reports_for_page(url, page_number, year_range, listing_xpath):
 
   if not results and not page_number:
     # No link on the first page, raise an error
-    raise AssertionError("No report links found for %s" % url)
+    raise inspector.NoReportsFoundError("Department of State (%s)" % url)
 
   for result in results:
     report = report_from(result.parent, year_range)

--- a/inspectors/treasury.py
+++ b/inspectors/treasury.py
@@ -95,6 +95,8 @@ def run(options):
     results = []
     results.extend(doc.select("tr.ms-rteTableOddRow-default"))
     results.extend(doc.select("tr.ms-rteTableEvenRow-default"))
+    if not results:
+      raise inspector.NoReportsFoundError("Treasury (%d)" % year)
     for result in results:
       report = audit_report_from(result, url, year_range)
       if report:
@@ -103,6 +105,8 @@ def run(options):
   for report_type, url in OTHER_URLS.items():
     doc = beautifulsoup_from_url(url)
     results = doc.select("#ctl00_PlaceHolderMain_ctl05_ctl01__ControlWrapper_RichHtmlField > p a")
+    if not results:
+      raise inspector.NoReportsFoundError("Treasury (%s)" % report_type)
     for result in results:
       report = report_from(result, url, report_type, year_range)
       if report:
@@ -110,6 +114,8 @@ def run(options):
 
   doc = beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
   results = doc.select("#ctl00_PlaceHolderMain_ctl05_ctl01__ControlWrapper_RichHtmlField > p > a")
+  if not results:
+    raise inspector.NoReportsFoundError("Treasury (semiannual reports)")
   for result in results:
     report = semiannual_report_from(result, SEMIANNUAL_REPORTS_URL, year_range)
     if report:

--- a/inspectors/tva.py
+++ b/inspectors/tva.py
@@ -32,6 +32,8 @@ def run(options):
     url = AUDIT_REPORTS_URL.format(year=year)
     doc = BeautifulSoup(utils.download(url))
     results = doc.select("div.content")
+    if not results:
+      raise inspector.NoReportsFoundError("Tennessee Valley Authority (%d)" % year)
     for result in results:
       report = audit_report_from(result, url, year_range)
       if report:
@@ -40,6 +42,8 @@ def run(options):
   # Pull the semiannual reports
   doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
   results = doc.select("report")
+  if not results:
+    raise inspector.NoReportsFoundError("Tennessee Valley Authority (semiannual reports)")
   for result in results:
     report = semiannual_report_from(result, year_range)
     if report:

--- a/inspectors/usaid.py
+++ b/inspectors/usaid.py
@@ -39,7 +39,10 @@ def run(options):
       doc = BeautifulSoup(utils.download(url))
       results = doc.select("li.views-row")
       if not results:
-        break
+        if page == 0:
+          raise inspector.NoReportsFoundError("USAID (%s)" % report_type)
+        else:
+          break
 
       for result in results:
         report = report_from(result, url, report_type, year_range)
@@ -49,6 +52,8 @@ def run(options):
   # Pull the semiannual reports (no pagination)
   doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
   results = doc.select("li.views-row")
+  if not results:
+    raise inspector.NoReportsFoundError("USAID (semiannual reports)")
   for result in results:
     report = semiannual_report_from(result, year_range)
     if report:

--- a/inspectors/usps.py
+++ b/inspectors/usps.py
@@ -52,7 +52,8 @@ def run(options):
     max_page = last_page_for(doc)
 
     results = doc.select(".views-row")
-
+    if not results:
+      raise inspector.NoReportsFoundError("USPS")
     for result in results:
       report = report_from(result)
 

--- a/inspectors/utils/inspector.py
+++ b/inspectors/utils/inspector.py
@@ -326,3 +326,10 @@ def year_range(options, archive):
     year_range = list(range(this_year, this_year + 1))
 
   return year_range
+
+class NoReportsFoundError(AssertionError):
+  def __init__(self, value):
+    self.value = value
+
+  def __str__(self):
+    return "No reports were found for %s" % self.value

--- a/inspectors/va.py
+++ b/inspectors/va.py
@@ -58,7 +58,10 @@ def run(options):
     doc = beautifulsoup_from_url("{}?RS={}".format(REPORTS_URL, page))
     results = doc.select("div.leadin")
     if not results:
-      break
+      if page == 1:
+        raise inspector.NoReportsFoundError("VA (audit reports)")
+      else:
+        break
     for result in results:
       report = report_from(result, year_range)
       if report:
@@ -67,6 +70,8 @@ def run(options):
   # Pull the semiannual reports
   doc = beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
   results = doc.select("div.leadin")
+  if not results:
+    raise inspector.NoReportsFoundError("VA (semiannual reports)")
   for result in results:
     report = semiannual_report_from(result, year_range)
     if report:


### PR DESCRIPTION
This adds checks throughout the codebase for when select() or find_all() return no elements. An exception will be thrown in such cases. I also fixed three scrapers that were half-broken with such problems.