### PR TITLE
Lock the version of requests explicitly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ scrapelib>=0.10.0
 BeautifulSoup4
 pyyaml
 lxml
+requests>=2.5.3
 
 # for backing up reports. can't use [speedups] while it depends on gevent.
 -e git+git://github.com/konklone/ia-wrapper.git@py3-hack#egg=internetarchive


### PR DESCRIPTION
This should also address some recurring `sba` failures.