### PR TITLE
 [fca] Skip certificate validation

### DIFF
--- a/inspectors/utils/utils.py
+++ b/inspectors/utils/utils.py
@@ -36,6 +36,7 @@ scraper.mount("https://www.sba.gov/", Tls1HttpAdapter())
 # ugh
 WHITELIST_INSECURE_DOMAINS = (
   "https://www.ignet.gov",
+  "https://www.fca.gov",
 )
 
 # will pass correct options on to individual scrapers whether


### PR DESCRIPTION
Good news: The FCA website now has a SHA-2 certificate
Bad news: The certificate chain provided by the server only goes back to the new Entrust SHA-2 root CA, and does not include the cross-signed certificate from the old SHA-1 root CA