### PR TITLE
USPS pagination fixes

### DIFF
--- a/inspectors/sba.py
+++ b/inspectors/sba.py
@@ -50,9 +50,6 @@ DUPLICATE_LANDING_URLS = (
 # The report list is not stable, so sometimes we need to fetch the same page of
 # results multiple times to get everything. This constant is the maximum
 # number of times we will do so.
-# For simplicity's sake, we will always retry the last page the maximum number
-# of times. There will probably be less than ten reports on the last page, which
-# fools our heuristic of counting how many unique reports we have seen.
 MAX_RETRIES = 10
 REPORTS_PER_PAGE = 10
 

--- a/inspectors/usps.py
+++ b/inspectors/usps.py
@@ -11,8 +11,6 @@ archive = 1998
 # options:
 #   standard since/year options for a year range to fetch from.
 #
-#   pages - number of pages to fetch. defaults to all of them (using a very high number)
-#   begin - what page number to begin at. defaults to 1.
 #   types - limit reports fetched to one or more types, comma-separated. e.g. "audit,testimony"
 #          can include:
 #             audit - Audit Reports
@@ -32,14 +30,11 @@ ALL_PAGES = 1000
 
 def run(options):
   year_range = inspector.year_range(options, archive)
-  pages = options.get('pages', ALL_PAGES)
-
-  # default to starting at page 1
-  begin = int(options.get('begin', 1))
+  pages = ALL_PAGES
 
   reports_seen = set()
   max_page = None
-  for page in range(begin, (int(pages) + 1)):
+  for page in range(1, pages + 1):
     if max_page and (page > max_page):
       logging.debug("End of pages!")
       break

--- a/inspectors/usps.py
+++ b/inspectors/usps.py
@@ -35,41 +35,41 @@ def run(options):
   reports_seen = set()
   max_page = None
   for page in range(1, pages + 1):
-    if max_page and (page > max_page):
-      logging.debug("End of pages!")
-      break
+      if max_page and (page > max_page):
+        logging.debug("End of pages!")
+        break
 
-    logging.debug("## Downloading page %i" % page)
-    url = url_for(options, page)
-    body = utils.download(url)
-    doc = BeautifulSoup(body)
+      logging.debug("## Downloading page %i" % page)
+      url = url_for(options, page)
+      body = utils.download(url)
+      doc = BeautifulSoup(body)
 
-    # When the USPS restores their page controls, we can use this again,
-    # which saves one network call each time.
-    max_page = last_page_for(doc)
+      # When the USPS restores their page controls, we can use this again,
+      # which saves one network call each time.
+      max_page = last_page_for(doc)
 
-    results = doc.select(".views-row")
-    if not results:
-      raise inspector.NoReportsFoundError("USPS")
-    for result in results:
-      report = report_from(result)
+      results = doc.select(".views-row")
+      if not results:
+        raise inspector.NoReportsFoundError("USPS")
+      for result in results:
+          report = report_from(result)
 
-      # inefficient enforcement of --year arg, USPS doesn't support it server-side
-      # TODO: change to published_on.year once it's a datetime
-      if inspector.year_from(report) not in year_range:
-        logging.warn("[%s] Skipping report, not in requested range." % report['report_id'])
-        continue
+          # inefficient enforcement of --year arg, USPS doesn't support it server-side
+          # TODO: change to published_on.year once it's a datetime
+          if inspector.year_from(report) not in year_range:
+            logging.warn("[%s] Skipping report, not in requested range." % report['report_id'])
+            continue
 
-      # Check if we've seen the exact same report twice. This happens because
-      # the document library's sort algorithm is not stable. If two reports
-      # have the same date, they switch places randomly, so each page doesn't
-      # necessarily have the same reports each time you load it.
-      dedup_key = (report['title'], report['url'], report['published_on'])
-      if dedup_key in reports_seen:
-        continue
+          # Check if we've seen the exact same report twice. This happens because
+          # the document library's sort algorithm is not stable. If two reports
+          # have the same date, they switch places randomly, so each page doesn't
+          # necessarily have the same reports each time you load it.
+          dedup_key = (report['title'], report['url'], report['published_on'])
+          if dedup_key in reports_seen:
+            continue
 
-      inspector.save_report(report)
-      reports_seen.add(dedup_key)
+          inspector.save_report(report)
+          reports_seen.add(dedup_key)
 
 
 # extract fields from HTML, return dict

--- a/inspectors/usps.py
+++ b/inspectors/usps.py
@@ -4,6 +4,7 @@ from utils import utils, inspector
 from bs4 import BeautifulSoup
 from datetime import datetime
 import logging
+import os.path
 
 archive = 1998
 #
@@ -112,9 +113,8 @@ def report_from(result):
   report['url'] = link
 
   # get filename, use name as report ID, extension for type
-  filename = link.split("/")[-1]
-  extension = filename.split(".")[-1]
-  report['report_id'] = filename.replace("." + extension, "")
+  filename = os.path.basename(link)
+  report['report_id'] = os.path.splitext(filename)[0]
 
   report['title'] = result.select("h3")[0].text.strip()
 

--- a/inspectors/usps.py
+++ b/inspectors/usps.py
@@ -5,6 +5,7 @@ from bs4 import BeautifulSoup
 from datetime import datetime
 import logging
 import os.path
+import time
 
 archive = 1998
 #
@@ -231,6 +232,9 @@ def url_for(options, page, category_id):
   # page is 0-indexed
   if page > 1:
     url += "&page=%s%i" % (annoying_prefix, (page - 1))
+
+  # Add a cache buster, this helps once we start retrying pages
+  url += "&t=%i" % int(time.time())
 
   return url
 


### PR DESCRIPTION
These changes will retry individual pages of the search results to get missing reports. This fixes the second half of #214.