### PR TITLE
Detect "Soft 404s"

### DIFF
--- a/inspectors/dod.py
+++ b/inspectors/dod.py
@@ -211,6 +211,10 @@ def report_from(tds, options):
   if (report_url is None) and maybe_unreleased:
     report['unreleased'] = True
 
+  # Fix typo
+  if report_url == "http://www.dodig.mil/fo/Foia/ERR/Lincoln%20Group_swa.pdf":
+    report_url = "http://www.dodig.mil/FOIA/ERR/Lincoln%20Group_swa.pdf"
+
   # broken reports: mark as unreleased, but also mark as broken
   # blacklisted reports, or, from now on, anything in 2001 and before
   # I'll investigate the batch of 'missing' later.

--- a/inspectors/dod.py
+++ b/inspectors/dod.py
@@ -211,9 +211,12 @@ def report_from(tds, options):
   if (report_url is None) and maybe_unreleased:
     report['unreleased'] = True
 
-  # Fix typo
+  # Fix typo, alternate source for missing report
   if report_url == "http://www.dodig.mil/fo/Foia/ERR/Lincoln%20Group_swa.pdf":
     report_url = "http://www.dodig.mil/FOIA/ERR/Lincoln%20Group_swa.pdf"
+  elif report_url == "http://www.dodig.mil/Audit/Audit2/92-032.pdf":
+    report_url = "http://www.dtic.mil/get-tr-doc/pdf?Location=U2&doc=GetTRDoc.pdf&AD=ADA378668"
+    report['file_type'] = "pdf"
 
   # broken reports: mark as unreleased, but also mark as broken
   # blacklisted reports, or, from now on, anything in 2001 and before

--- a/inspectors/dod.py
+++ b/inspectors/dod.py
@@ -293,7 +293,10 @@ def fetch_from_landing_page(landing_url):
 
   href = link['href'].strip() if link else None
   if href and add_pdf:
-    href = href + ".pdf"
+    if href.endswith(".pd"):
+      href = href + "f"
+    else:
+      href = href + ".pdf"
 
   # some URLs have "/../" in the middle, and the redirects are trouble
   if href:

--- a/inspectors/gsa.py
+++ b/inspectors/gsa.py
@@ -75,7 +75,7 @@ def url_for(base_url, page = 1):
 def report_from(result, base_url):
   report = {
     'inspector': 'gsa',
-    'inspector_url': 'http://gsaig.gov/',
+    'inspector_url': 'http://www.gsaig.gov/',
     'agency': 'gsa',
     'agency_name': 'General Services Administration'
   }

--- a/inspectors/smithsonian.py
+++ b/inspectors/smithsonian.py
@@ -35,6 +35,27 @@ RECENT_AUDITS_URL = "http://www.si.edu/OIG/Audits"
 AUDIT_ARCHIVE_URL = "http://www.si.edu/oig/Archive"
 OTHER_REPORTS_URl = "http://www.si.edu/OIG/ReportsToCongress"
 
+RSS_BROKEN_LINKS = {
+  "http://www.si.edu/Content/OIG/Misc/Peer_Review_09-21-2011.pdf":
+    "http://www.si.edu/Content/OIG/Misc/Peer_Review_09-21-11.pdf",
+  "http://www.si.edu/oig/RecoveryAct.htm":
+    "http://www.si.edu/OIG/Recovery",
+  "http://www.si.edu/oig/AuditReports/UnderstandingAudits.pdf":
+    "http://www.si.edu/Content/OIG/Misc/UnderstandingAudits.pdf",
+  "http://www.si.edu/oig/AuditReports/A-0907-FSA-Oversight.pdf":
+    "http://www.si.edu/Content/OIG/Audits/2010/A-09-07.pdf",
+  "http://www.si.edu/oig/ARRA_Reports/M-10--04-1.pdf":
+    "http://www.si.edu/Content/OIG/Audits/M-10-04-1.pdf",
+  "http://www.si.edu/oig/AuditReports/SIIG_Testimony_121009.pdf":
+    "http://www.si.edu/Content/OIG/Testimony/SIIG_Testimony_121009.pdf",
+  "http://www.si.edu/oig/AuditReports/IBA-0902.pdf":
+    "http://www.si.edu/Content/OIG/Audits/2009/IBA-09-02.pdf",
+  "http://www.si.edu/oig/AuditReports/IBA-0808.pdf":
+    "http://www.si.edu/Content/OIG/Audits/2009/IBA-08-08.pdf",
+  "http://www.si.edu/oig/AuditReports/A-08-05-FSA-Oversight-Letter.pdf":
+    "http://www.si.edu/Content/OIG/Audits/2009/A-08-05.pdf",
+}
+
 report_ids_seen = set()
 
 def run(options):
@@ -100,6 +121,19 @@ def rss_report_from(result, year_range):
     # This is the default url the IG uses for announcements of things like
     # a website redesign or changes to the RSS feed.
     return
+
+  if report_url == "http://www.si.edu/oig/OIGStratPlan.pdf":
+    # This strategic plan is no longer on the website, but it is reproduced in
+    # multiple semiannual reports, so we skip it here.
+    return
+
+  if report_url in RSS_BROKEN_LINKS:
+    report_url = RSS_BROKEN_LINKS[report_url]
+  else:
+    report_url = report_url.replace("/OIG/SAR/Semiannual_Reports/", "/OIG/SAR/")
+    report_url = report_url.replace("/oig/Semiannual_Reports/", "/Content/OIG/SAR/")
+    report_url = report_url.replace("/oig/AuditReports/", "/Content/OIG/Audits/")
+    report_url = report_url.replace("/oig/ARRA_Reports/", "/Content/OIG/Audits/")
 
   file_type = None
   if not report_url.endswith(".pdf"):

--- a/inspectors/utils/utils.py
+++ b/inspectors/utils/utils.py
@@ -7,9 +7,6 @@ from bs4 import BeautifulSoup
 from datetime import datetime
 import ssl
 import requests
-import requests.adapters
-import requests.packages.urllib3.poolmanager
-import requests.packages.urllib3.response
 import urllib.parse
 import io
 import gzip

--- a/inspectors/utils/utils.py
+++ b/inspectors/utils/utils.py
@@ -24,7 +24,7 @@ class Soft404HttpAdapter(requests.adapters.HTTPAdapter):
   """Transport adapter that checks all responses against a blacklist of "file
   not found" pages that are served with 200 status codes."""
 
-  SOFT_404_URLS_RE = re.compile(r"^(http://www\.cftc\.gov/cgi-bin/missing\.pl\?.*|http://www\.dodig\.mil/errorpages/index\.html|/404-error-content\.cfm|http://www\.fec\.gov/404error\.shtml|http://www\.gpo\.gov/maintenance/error\.htm)$")
+  SOFT_404_URLS_RE = re.compile(r"^(http://www\.cftc\.gov/cgi-bin/missing\.pl\?.*|http://www\.dodig\.mil/errorpages/index\.html|http://www\.fec\.gov/404error\.shtml|http://www\.gpo\.gov/maintenance/error\.htm)$")
   SOFT_404_BODY_SIGNATURES = {
     "cpb.org": b"<title>CPB: Page Not Found</title>",
     "ncua.gov": b"Redirect.aspx?404",
@@ -63,8 +63,6 @@ scraper.mount("http://www.cftc.gov/", Soft404HttpAdapter())
 scraper.mount("http://cftc.gov/", Soft404HttpAdapter())
 scraper.mount("http://www.dodig.mil/", Soft404HttpAdapter())
 scraper.mount("http://dodig.mil/", Soft404HttpAdapter())
-scraper.mount("http://www.exim.gov/", Soft404HttpAdapter())
-scraper.mount("http://exim.gov/", Soft404HttpAdapter())
 scraper.mount("http://www.fec.gov/", Soft404HttpAdapter())
 scraper.mount("http://fec.gov/", Soft404HttpAdapter())
 scraper.mount("http://www.gpo.gov/", Soft404HttpAdapter())

--- a/inspectors/utils/utils.py
+++ b/inspectors/utils/utils.py
@@ -49,12 +49,13 @@ class Soft404HttpAdapter(requests.adapters.HTTPAdapter):
         )
         if data.find(self.SOFT_404_BODY_SIGNATURES[base_domain], 0, 10240) != -1:
           result = super(Soft404HttpAdapter, self).build_response(req, resp)
-          raise scrapelib.HTTPError(result)
+          result.status_code = 404 # tells scrapelib to not retry
+          return result
 
     redirect = resp.get_redirect_location()
     result = super(Soft404HttpAdapter, self).build_response(req, resp)
     if redirect and self.SOFT_404_URLS_RE.match(redirect):
-      raise scrapelib.HTTPError(result)
+      result.status_code = 404 # tells scrapelib to not retry
 
     return result
 

--- a/scripts/soft_404.py
+++ b/scripts/soft_404.py
@@ -5,7 +5,7 @@ import re
 from inspectors.utils import utils
 import logging
 
-PAGE_NOT_FOUND_PATTERN = b"(<title>(404 Page Not Found - CFTC|CPB: Page Not Found|DoD IG - Error Message|404: NOT FOUND|Page Not Found|Maintenance|Page Not Found Smithsonian|404)</title>|That page was not found\\.&#160; If possible we will redirect you to that content now\\.|The Office of Inspector General [(]OIG[)] is an independent unit established by law which is responsible for promoting economy, efficiency, and effectiveness and detecting and preventing fraud, waste, and mismanagement in the General Services Administration's [(]GSA[)] programs and operations\\.)"
+PAGE_NOT_FOUND_PATTERN = b"(<title>(404 Page Not Found - CFTC|CPB: Page Not Found|DoD IG - Error Message|404: NOT FOUND|Page Not Found|Maintenance|Page Not Found Smithsonian|404)</title>|That page was not found\\.&#160; If possible we will redirect you to that content now\\.)"
 PAGE_NOT_FOUND_BYTES_RE = re.compile(PAGE_NOT_FOUND_PATTERN)
 PAGE_NOT_FOUND_STRING_RE = re.compile(PAGE_NOT_FOUND_PATTERN.decode('ascii'))
 
@@ -16,7 +16,6 @@ URLS = {
   'exim': 'http://www.exim.gov/oig/doesyour404work',
   'fec': 'http://www.fec.gov/fecig/doesyour404work',
   'gpo': 'http://www.gpo.gov/oig/doesyour404work',
-  'gsa': 'http://gsaig.gov/doesyour404work',
   'ncua': 'http://www.ncua.gov/about/Leadership/Pages/doesyour404work',
   'smithsonian': 'http://www.si.edu/OIG/doesyour404work',
 }

--- a/scripts/soft_404.py
+++ b/scripts/soft_404.py
@@ -13,7 +13,6 @@ URLS = {
   'cftc': 'http://www.cftc.gov/About/OfficeoftheInspectorGeneral/doesyour404work',
   'cpb': 'http://www.cpb.org/oig/doesyour404work',
   'dod': 'http://www.dodig.mil/doesyour404work',
-  'exim': 'http://www.exim.gov/oig/doesyour404work',
   'fec': 'http://www.fec.gov/fecig/doesyour404work',
   'gpo': 'http://www.gpo.gov/oig/doesyour404work',
   'ncua': 'http://www.ncua.gov/about/Leadership/Pages/doesyour404work',

--- a/scripts/soft_404.py
+++ b/scripts/soft_404.py
@@ -19,7 +19,6 @@ URLS = {
   'gsa': 'http://gsaig.gov/doesyour404work',
   'ncua': 'http://www.ncua.gov/about/Leadership/Pages/doesyour404work',
   'smithsonian': 'http://www.si.edu/OIG/doesyour404work',
-  'state': 'http://oig.state.gov/doesyour404work'
 }
 
 IGS_WITH_BAD_404 = tuple(URLS.keys())

--- a/scripts/soft_404.py
+++ b/scripts/soft_404.py
@@ -52,7 +52,7 @@ def run(options):
       match = PAGE_NOT_FOUND_STRING_RE.search(result)
       if not match:
         print("False negative for %s (regular expression did not match error "
-              "page contents" % inspector)
+              "page contents)" % inspector)
 
   data_dir = utils.data_dir()
   for inspector in os.listdir(data_dir):


### PR DESCRIPTION
Some servers do not properly return an error status code when they can't find the page for a URL. This pull request will register a requests TransportAdapter for these servers to detect such cases and throw an exception.

In most cases, the server first gives a redirect to a "page not found" page, which is in turn served with a 200 status code. In those cases, the TransportAdapter checks the redirect URL against a blacklist, and raises an exception based on that. For other sites where no redirect is involved, and the server always responds with a status code of 200, the TransportAdapter will check a telltale header, read the data, and check it for specific strings. If the TransportAdapter had to read the body of a response, it will mock up a new response to pass along the data.

So far, I found a lot of broken links in the DOD and Smithsonian scrapers; I'll investigate those and round out this PR with appropriate fixes.

- [x] cftc (No broken links found)
- [x] dod (Fixed some broken links, more to check)
- [x] exim (No broken links found)
- [x] fec (No broken links found)
- [x] gpo (No broken links found)
- [x] cpb (No broken links found)
- [x] ncua (No broken links found)
- [x] smithsonian (Many broken links to fix)