### PR TITLE
[WIP] [loc] HTTPS URLs and other cleanup

### DIFF
--- a/inspectors/loc.py
+++ b/inspectors/loc.py
@@ -106,8 +106,8 @@ class LibraryOfCongressScraper(object):
       self.get_bare_reports(ul)
 
   def get_semiannual_reports_to_congress(self, doc):
-    header = doc.find_all(text=re.compile('Semiannual Reports'))
-    ul = header[0].parent.find_next_sibling()
+    header = doc.find_all('h2', text=re.compile('Semiannual Reports'))
+    ul = header[0].find_next_sibling()
     results = ul.find_all('li')
     if not results:
       raise inspector.NoReportsFoundError("Library of Congress (semiannual reports)")

--- a/inspectors/loc.py
+++ b/inspectors/loc.py
@@ -8,7 +8,7 @@ import re
 from bs4 import BeautifulSoup
 from utils import utils, inspector
 
-# http://www.loc.gov/about/office-of-the-inspector-general/
+# https://www.loc.gov/about/office-of-the-inspector-general/
 archive = 2001
 
 # options:
@@ -17,9 +17,9 @@ archive = 2001
 # Notes for IG's web team:
 #
 
-REPORTS_BY_YEAR_URL = 'http://www.loc.gov/about/office-of-the-inspector-general/annual-reports/'
-REPORTS_TESTIMONY_URL = 'http://www.loc.gov/about/office-of-the-inspector-general/congressional-testimony/'
-REPORTS_PEER_REVIEWS_URL = 'http://www.loc.gov/about/office-of-the-inspector-general/peer-reviews/'
+REPORTS_BY_YEAR_URL = 'https://www.loc.gov/about/office-of-the-inspector-general/annual-reports/'
+REPORTS_TESTIMONY_URL = 'https://www.loc.gov/about/office-of-the-inspector-general/congressional-testimony/'
+REPORTS_PEER_REVIEWS_URL = 'https://www.loc.gov/about/office-of-the-inspector-general/peer-reviews/'
 
 OTHER_REPORTS = {
   'http://lcweb2.loc.gov/master/libn/about/office-of-the-inspector-general/documents/LCR211-6-oct2010.pdf': '2010-10-01'
@@ -225,7 +225,7 @@ class LibraryOfCongressScraper(object):
 
     report = {
       'inspector': 'loc',
-      'inspector_url': 'http://www.loc.gov/about/office-of-the-inspector-general/',
+      'inspector_url': 'https://www.loc.gov/about/office-of-the-inspector-general/',
       'agency': agency,
       'agency_name': agency_name,
       'report_id': report_id,


### PR DESCRIPTION
Here's what I have so far for #230. I've started getting 503 errors for PDFs, both over http and https, which is hampering testing.

I had to make another change to the code, in the semiannual reports section. The selector code there was tripping up on an analytics <script> tag, and I was getting a `NoReportsFoundError` from it. This wasn't showing up in the #errors channel, which seems suspicious.