### PR TITLE
SHA-1 CA bundle

### DIFF
--- a/inspectors/utils/utils.py
+++ b/inspectors/utils/utils.py
@@ -99,7 +99,8 @@ class Tls1HttpAdapter(requests.adapters.HTTPAdapter):
 
 scraper.mount("https://www.sba.gov/", Tls1HttpAdapter())
 
-# ugh
+# The IGnet and FHFA OIG websites require extra certificate downloads, as of
+# 10/2/2015
 WHITELIST_INSECURE_DOMAINS = (
   "https://www.ignet.gov/",
   "https://origin.www.fhfaoig.gov/",

--- a/inspectors/utils/utils.py
+++ b/inspectors/utils/utils.py
@@ -102,9 +102,7 @@ scraper.mount("https://www.sba.gov/", Tls1HttpAdapter())
 # ugh
 WHITELIST_INSECURE_DOMAINS = (
   "https://www.ignet.gov/",
-  "https://www.fca.gov/",
   "https://origin.www.fhfaoig.gov/",
-  "https://www.sigar.mil/",
 
   # The following domains will 301/302 redirect to the above domains, so
   # validate=False is needed for these cases as well
@@ -112,12 +110,13 @@ WHITELIST_INSECURE_DOMAINS = (
   "http://ignet.gov/",
   "http://www.fhfaoig.gov/",
   "http://fhfaoig.gov/",
-  "http://www.sigar.mil/",
 )
 WHITELIST_SHA1_DOMAINS = (
   "https://www.sba.gov/",
   "http://www.sba.gov/",
   "http://sba.gov/",
+  "https://www.sigar.mil/",
+  "http://www.sigar.mil/",
 )
 
 # will pass correct options on to individual scrapers whether


### PR DESCRIPTION
This is a followup from #245, see [this comment](https://github.com/unitedstates/inspectors-general/pull/245#issuecomment-142768185).

Older versions of OpenSSL have issues building the correct certificate chain in the presence of cross-signed CAs. When communicating with servers that trigger this problem, (i.e. SBA and SIGAR) we should instead use certifi's legacy bundle, which includes roots that issued SHA-1 certificates.

Newer versions of OpenSSL have features and options to improve the situation, such as X509_V_FLAG_TRUSTED_FIRST and a new "alternate chains" algorithm. However, X509_V_FLAG_TRUSTED_FIRST is not yet exposed to Python; `ssl.VERIFY_X509_TRUSTED_FIRST` will first be released in the forthcoming Python 3.4.4, where it will be set by default. The alternate chains algorithm has only been released for newer versions of 1.0.1 and 1.0.2, which aren't yet in Debian stable. (c.f. http://curl.haxx.se/mail/lib-2015-05/0175.html and https://www.openssl.org/news/secadv/20150709.txt)

Further reading: https://lukasa.co.uk/2015/04/Certifi_State_Of_Union/ and certifi/python-certifi#26