### PR TITLE
Remove BeautifulSoup warning, force it to use lxml

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ We don't yet have a formal process for submitting reports &mdash; for now, eithe
 
 * To extract PDFs (the most common type of report), you'll need `pdftotext` and `pdfinfo`. On Ubuntu, `apt-get install poppler-utils`. On OS X, `brew install poppler`.
 * To extract DOCs, you'll need [`abiword`](http://www.abisource.com/), which you can install via `apt-get` or `brew`.
+* Install all the PIP dependencies by running `pip install -r requirements.txt`
 
 To run an individual IG scraper, just execute its file directly. For example:
 

--- a/inspectors/agriculture.py
+++ b/inspectors/agriculture.py
@@ -124,7 +124,7 @@ def run(options):
   all_audit_reports = {}
   for agency_slug, agency_path in AGENCY_URLS.items():
     agency_url = urljoin(AGENCY_BASE_URL, agency_path)
-    doc = beautifulsoup_from_url(agency_url)
+    doc = utils.beautifulsoup_from_url(agency_url)
     results = doc.select("ul li")
     if not results:
       results = [ancestor_tag_by_name(x, 'tr') for x in \
@@ -148,7 +148,7 @@ def run(options):
     inspector.save_report(report)
 
   for report_type, url in OTHER_REPORT_TYPES.items():
-    doc = beautifulsoup_from_url(url)
+    doc = utils.beautifulsoup_from_url(url)
     results = doc.select("ul li")
     if not results:
       raise inspector.NoReportsFoundError("Department of Agriculture (other reports)")
@@ -303,10 +303,6 @@ def report_from(result, page_url, year_range, report_type, agency_slug="agricult
     'published_on': datetime.datetime.strftime(published_on, "%Y-%m-%d"),
   }
   return report
-
-def beautifulsoup_from_url(url):
-  body = utils.download(url)
-  return BeautifulSoup(body)
 
 def ancestor_tag_by_name(element, name):
   for parent in element.parents:

--- a/inspectors/agriculture.py
+++ b/inspectors/agriculture.py
@@ -5,7 +5,6 @@ import logging
 import os
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 

--- a/inspectors/amtrak.py
+++ b/inspectors/amtrak.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from utils import utils, inspector
-from bs4 import BeautifulSoup
 from datetime import datetime
 
 archive = 2006

--- a/inspectors/amtrak.py
+++ b/inspectors/amtrak.py
@@ -19,9 +19,7 @@ def run(options):
     report_count = 0
     for year in year_range:
       url = url_for(options, index, year)
-      body = utils.download(url)
-
-      doc = BeautifulSoup(body)
+      doc = utils.beautifulsoup_from_url(url)
 
       results = doc.select("div.view-content div.views-row")
       for result in results:

--- a/inspectors/arc.py
+++ b/inspectors/arc.py
@@ -5,7 +5,6 @@ import logging
 import os
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.arc.gov/oig

--- a/inspectors/arc.py
+++ b/inspectors/arc.py
@@ -32,7 +32,7 @@ def run(options):
 
   # Pull the audit reports
   for report_type, url in REPORT_TYPES.items():
-    doc = BeautifulSoup(utils.download(url))
+    doc = utils.beautifulsoup_from_url(url)
     results = doc.select("table p > a[href]")
     if not results:
       raise inspector.NoReportsFoundError("ARC (%s)" % report_type)

--- a/inspectors/archives.py
+++ b/inspectors/archives.py
@@ -30,7 +30,7 @@ def run(options):
     if year < 2006:  # The oldest year for audit reports
       continue
     url = AUDIT_REPORTS_URL.format(year=year)
-    doc = BeautifulSoup(utils.download(url))
+    doc = utils.beautifulsoup_from_url(url)
     results = doc.select("div#content li")
     if not results:
       raise inspector.NoReportsFoundError("National Archives and Records Administration audit reports")
@@ -40,7 +40,7 @@ def run(options):
         inspector.save_report(report)
 
   # Pull the semiannual reports
-  doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
   results = doc.select("div#content li")
   if not results:
     raise inspector.NoReportsFoundError("National Archives and Records Administration semiannual reports")
@@ -50,7 +50,7 @@ def run(options):
       inspector.save_report(report)
 
   # Pull the Peer Review
-  doc = BeautifulSoup(utils.download(PEER_REVIEWS_URL))
+  doc = utils.beautifulsoup_from_url(PEER_REVIEWS_URL)
   result = doc.find("div", id='content').find("a", text=True)
   report = peer_review_from(result, year_range)
   if report:

--- a/inspectors/archives.py
+++ b/inspectors/archives.py
@@ -6,7 +6,6 @@ import os
 import re
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.archives.gov/oig/

--- a/inspectors/cftc.py
+++ b/inspectors/cftc.py
@@ -6,7 +6,6 @@ import os
 import re
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.cftc.gov/About/OfficeoftheInspectorGeneral/index.htm

--- a/inspectors/cftc.py
+++ b/inspectors/cftc.py
@@ -32,7 +32,7 @@ def run(options):
   year_range = inspector.year_range(options, archive)
 
   # Pull the audit reports
-  doc = BeautifulSoup(utils.download(REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(REPORTS_URL)
   results = doc.select("ul.text > ul > li")
   if not results:
     raise inspector.NoReportsFoundError("CFTC audit reports")

--- a/inspectors/cncs.py
+++ b/inspectors/cncs.py
@@ -6,7 +6,6 @@ import os
 import re
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.cncsoig.gov

--- a/inspectors/cncs.py
+++ b/inspectors/cncs.py
@@ -47,7 +47,7 @@ def run(options):
     last_page = options.get("end") # reset for each area
     while True:
       url = url_for(reports_page, page)
-      doc = BeautifulSoup(utils.download(url))
+      doc = utils.beautifulsoup_from_url(url)
 
       if last_page is None:
         last_page = last_page_from(doc)
@@ -224,7 +224,7 @@ def do_peer_review():
 
 # gets URL and summary from a report's landing page
 def extract_from_release_page(landing_url):
-  doc = BeautifulSoup(utils.download(landing_url))
+  doc = utils.beautifulsoup_from_url(landing_url)
   main = doc.select("#main #lefSide")[0]
 
   url_elem = main.select("div")[2].select("a")

--- a/inspectors/commerce.py
+++ b/inspectors/commerce.py
@@ -5,7 +5,6 @@ import logging
 import os
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.oig.doc.gov/Pages/Audits-Evaluations.aspx?YearStart=01/01/1996&YearEnd=12/31/2014

--- a/inspectors/commerce.py
+++ b/inspectors/commerce.py
@@ -66,7 +66,7 @@ def extract_reports_for_topic(topic, year_range):
 
   topic_url = url_for(year_range).format(TOPIC_TO_URL_SLUG[topic])
 
-  topic_page = beautifulsoup_from_url(topic_url)
+  topic_page = utils.beautifulsoup_from_url(topic_url)
   results = topic_page.select("div.row")
   if not results:
     temp_text = topic_page.select("div.item")[0].text
@@ -118,7 +118,7 @@ def report_from(result, topic, topic_url, year_range):
       # Duplicate of http://www.oig.doc.gov/Pages/Letter-to-Sens-Snowe-Collins-Kennedy-Kerry-re-Investigation-Work-Scientific-Methods-of-NMFS-NFSC-2009.02.26.aspx
       return
 
-    landing_page = beautifulsoup_from_url(landing_url)
+    landing_page = utils.beautifulsoup_from_url(landing_url)
     try:
       if landing_url.endswith("/Top-Management-Challenges-FY-2011.aspx") or \
                 landing_url.endswith("/Observations-and-Address-Listers-" \
@@ -179,9 +179,5 @@ def report_from(result, topic, topic_url, year_range):
   if file_type:
     result['file_type'] = file_type
   return result
-
-def beautifulsoup_from_url(url):
-  body = utils.download(url)
-  return BeautifulSoup(body)
 
 utils.run(run) if (__name__ == "__main__") else None

--- a/inspectors/cpb.py
+++ b/inspectors/cpb.py
@@ -44,7 +44,7 @@ def run(options):
 
   # Pull the reports
   for report_type, url in REPORT_TYPE_MAP.items():
-    doc = BeautifulSoup(utils.download(url))
+    doc = utils.beautifulsoup_from_url(url)
     results = doc.select("div#content div#contentMain ul li.pdf")
     if not results:
       raise inspector.NoReportsFoundError("CPB (%s)" % url)

--- a/inspectors/cpb.py
+++ b/inspectors/cpb.py
@@ -5,7 +5,6 @@ import re
 import logging
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.cpb.org/oig/

--- a/inspectors/cpsc.py
+++ b/inspectors/cpsc.py
@@ -27,7 +27,7 @@ BLACKLIST_REPORT_URLS = [
 def run(options):
   year_range = inspector.year_range(options, archive)
 
-  doc = BeautifulSoup(utils.download(REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(REPORTS_URL)
   results = doc.select("ul.summary-list li")
   if not results:
     raise inspector.NoReportsFoundError("CPSC")

--- a/inspectors/cpsc.py
+++ b/inspectors/cpsc.py
@@ -6,7 +6,6 @@ import os
 import re
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.cpsc.gov/en/about-cpsc/inspector-general/

--- a/inspectors/denali.py
+++ b/inspectors/denali.py
@@ -32,7 +32,7 @@ DATE_RE = re.compile("(20[0-9][0-9]\\.[01][0-9])(?: *- *(.*))?")
 def run(options):
   year_range = inspector.year_range(options, archive)
 
-  doc = BeautifulSoup(utils.download(REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(REPORTS_URL)
 
   results = None
   for section in doc.find_all("section"):

--- a/inspectors/denali.py
+++ b/inspectors/denali.py
@@ -6,7 +6,7 @@ import os
 import re
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup, Tag
+from bs4 import Tag
 from utils import utils, inspector
 
 # http://www.oig.denali.gov/

--- a/inspectors/dhs.py
+++ b/inspectors/dhs.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from utils import utils, inspector
-from bs4 import BeautifulSoup
 from datetime import datetime
 import urllib.parse
 import logging

--- a/inspectors/dhs.py
+++ b/inspectors/dhs.py
@@ -34,9 +34,7 @@ def run(options):
   for component in components:
     logging.info("## Fetching reports for component %s" % component)
     url = url_for(options, component)
-    body = utils.download(url)
-
-    doc = BeautifulSoup(body)
+    doc = utils.beautifulsoup_from_url(url)
 
     results = doc.select("table.contentpaneopen table[border=1] tr")
     # accept only trs that look like body tr's (no 'align' attribute)

--- a/inspectors/dod.py
+++ b/inspectors/dod.py
@@ -145,8 +145,7 @@ def run(options):
     only = list(OFFICES.keys())
 
   for url in urls_for(options, only):
-    body = utils.download(url)
-    page = BeautifulSoup(body)
+    page = utils.beautifulsoup_from_url(url)
 
     report_table = page.select('table[summary~="reports"]')[0]
     for tr in report_table.select('tr')[1:]:
@@ -250,8 +249,7 @@ def fetch_from_landing_page(landing_url):
   add_pdf = False
   skip = False
 
-  body = utils.download(landing_url)
-  page = BeautifulSoup(body)
+  page = utils.beautifulsoup_from_url(landing_url)
 
   report_tables = page.select('table[summary~="reports"]')
   # in the rare case that doesn't work, have faith
@@ -334,8 +332,7 @@ def urls_for(options, only):
     url = '{0}?{1}'.format(BASE_URL, query_string)
     yield url
 
-    body = utils.download(url)
-    page = BeautifulSoup(body)
+    page = utils.beautifulsoup_from_url(url)
 
     for url in get_pagination_urls(page):
       yield url
@@ -353,7 +350,7 @@ def get_pagination_urls(page):
       yield BASE_URL + link['href']
     elif link['href'].startswith('/pubs') and RE_NEXT_10.search(link.text):
       new_url = urljoin(BASE_URL, link['href'])
-      page = BeautifulSoup(utils.download(new_url))
+      page = utils.beautifulsoup_from_url(new_url)
       for link in get_pagination_urls(page):
         yield link
 

--- a/inspectors/dod.py
+++ b/inspectors/dod.py
@@ -5,7 +5,6 @@ from urllib.parse import urljoin, urlencode
 import re
 import os
 import logging
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.dodig.mil/pubs/index.cfm

--- a/inspectors/doj.py
+++ b/inspectors/doj.py
@@ -15,7 +15,6 @@ archive = 1994
 #               will be used to filter to a particular landing page.
 
 import re
-from bs4 import BeautifulSoup
 from datetime import datetime
 from utils import utils, inspector
 import logging

--- a/inspectors/doj.py
+++ b/inspectors/doj.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#B!/usr/bin/env python
 
 # - Some documents don't have dates, in that case today's date is used
 # - Some forms, marked index are one html document spread across several links,
@@ -488,8 +488,7 @@ def type_for(original_type):
     return None
 
 def get_content(url):
-  page = utils.download(url)
-  page = BeautifulSoup(page)
+  page = utils.beautifulsoup_from_url(url)
   content = page.select(".content-left")
   if not content:
     raise inspector.NoReportsFoundError("DOJ (%s)" % url)

--- a/inspectors/dot.py
+++ b/inspectors/dot.py
@@ -4,7 +4,6 @@ import datetime
 from urllib.parse import urljoin
 import os
 import logging
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # https://www.oig.dot.gov/

--- a/inspectors/dot.py
+++ b/inspectors/dot.py
@@ -77,9 +77,7 @@ def run(options):
     year_urls = urls_for(year_range, topic)
     for year_url in year_urls:
       logging.debug("Scraping %s" % year_url)
-      body = utils.download(year_url)
-
-      doc = BeautifulSoup(body)
+      doc = utils.beautifulsoup_from_url(year_url)
 
       if not doc.select(".view-business-areas"):
         raise inspector.NoReportsFoundError("DOT (%s)" % topic)
@@ -127,8 +125,7 @@ def report_from(result, year_range, topic, options):
 
   logging.debug("### Processing report %s" % landing_url)
 
-  report_page_body = utils.download(landing_url)
-  report_page = BeautifulSoup(report_page_body)
+  report_page = utils.beautifulsoup_from_url(landing_url)
 
   # take an expansive view of the 'summary' -
   #   landing page title, and any paragraphs with summary text

--- a/inspectors/eac.py
+++ b/inspectors/eac.py
@@ -6,7 +6,6 @@ import os
 import re
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.eac.gov/inspector_general/

--- a/inspectors/eac.py
+++ b/inspectors/eac.py
@@ -39,7 +39,7 @@ def run(options):
 
   # Pull the reports
   for report_type, url in REPORT_URLS.items():
-    doc = BeautifulSoup(utils.download(url))
+    doc = utils.beautifulsoup_from_url(url)
     results = doc.select("div.mainRegion p a")
     if not results:
       raise inspector.NoReportsFoundError("EAC (%s)" % url)

--- a/inspectors/education.py
+++ b/inspectors/education.py
@@ -68,7 +68,7 @@ def run(options):
       else:
         pre_1998_audit_flag = True
     url = audit_url_for(year)
-    doc = beautifulsoup_from_url(url)
+    doc = utils.beautifulsoup_from_url(url)
     agency_tables = doc.find_all("table", {"border": 1})
     if not agency_tables:
       raise inspector.NoReportsFoundException("Department of Education (%d audit reports)" % year)
@@ -87,7 +87,7 @@ def run(options):
           inspector.save_report(report)
 
   # Get semiannual reports
-  doc = beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
+  doc = utils.beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
   table = doc.find("table", {"border": 1})
   for index, result in enumerate(table.select("tr")):
     if index < 2:
@@ -102,7 +102,7 @@ def run(options):
 
   # Get other reports
   for report_type, url in OTHER_REPORTS_URL.items():
-    doc = beautifulsoup_from_url(url)
+    doc = utils.beautifulsoup_from_url(url)
     results = doc.select("div.contentText ul li")
     if not results:
       raise inspector.NoReportsFoundException("Department of Education (%s)" % report_type)
@@ -297,10 +297,6 @@ def report_from(result, url, report_type, year_range):
     'published_on': datetime.datetime.strftime(published_on, "%Y-%m-%d"),
   }
   return report
-
-def beautifulsoup_from_url(url):
-  body = utils.download(url)
-  return BeautifulSoup(body)
 
 
 utils.run(run) if (__name__ == "__main__") else None

--- a/inspectors/education.py
+++ b/inspectors/education.py
@@ -6,7 +6,6 @@ import os
 import re
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # https://www2.ed.gov/about/offices/list/oig/areports.html

--- a/inspectors/eeoc.py
+++ b/inspectors/eeoc.py
@@ -31,7 +31,7 @@ def run(options):
   year_range = inspector.year_range(options, archive)
 
   # Pull the reports
-  doc = BeautifulSoup(utils.download(REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(REPORTS_URL)
   semiannual_report_results, other_results = doc.select("table tr")[1].select("td")
 
   if not semiannual_report_results:

--- a/inspectors/eeoc.py
+++ b/inspectors/eeoc.py
@@ -6,7 +6,6 @@ import os
 import re
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.eeoc.gov/eeoc/oig/index.cfm

--- a/inspectors/energy.py
+++ b/inspectors/energy.py
@@ -103,7 +103,7 @@ class EnergyScraper(object):
     self.last_date = datetime.datetime(self.year_range[-1], 12, 31)
 
     for url in self.urls_for():
-      page = BeautifulSoup(utils.download(url))
+      page = utils.beautifulsoup_from_url(url)
 
       nodes = page.select('.energy-listing__results .node')
       if not nodes:
@@ -195,7 +195,7 @@ class EnergyScraper(object):
   def fetch_from_landing_page(self, landing_url):
     """Returns a tuple of (pdf_link, summary_text, is_unreleased)."""
     unreleased = False
-    page = BeautifulSoup(utils.download(landing_url))
+    page = utils.beautifulsoup_from_url(landing_url)
 
     summary = None
     field_items = page.select('.field-items')
@@ -242,7 +242,7 @@ class EnergyScraper(object):
 
     # Not getting reports from specific topics, iterate over all Calendar Year
     # reports.
-    page = BeautifulSoup(utils.download(BASE_URL))
+    page = utils.beautifulsoup_from_url(BASE_URL)
 
     # Iterate over each "Calendar Year XXXX" link
     for li in page.select('.field-items li'):
@@ -258,7 +258,7 @@ class EnergyScraper(object):
           # Next, read all the pagination links for the page and yield those. So
           # far, I haven't seen a page that doesn't have all of the following
           # pages enumerated.
-          next_page = BeautifulSoup(utils.download(next_url))
+          next_page = utils.beautifulsoup_from_url(next_url)
           for link in next_page.select('li.pager-item a'):
             yield urljoin(BASE_URL, link['href'])
 
@@ -275,14 +275,14 @@ class EnergyScraper(object):
       last_page = False
 
       url = TOPIC_TO_URL[topic]
-      page = BeautifulSoup(utils.download(url))
+      page = utils.beautifulsoup_from_url(url)
       page_started = self.is_first_page(page)
       if page_started:
         yield url
 
       for link in page.select('li.pager-item a'):
         next_url = urljoin(url, link['href'])
-        next_page = BeautifulSoup(utils.download(next_url))
+        next_page = utils.beautifulsoup_from_url(next_url)
         if not page_started:
           page_started = self.is_first_page(next_page)
         if page_started:

--- a/inspectors/energy.py
+++ b/inspectors/energy.py
@@ -4,7 +4,6 @@ import datetime
 from urllib.parse import urljoin
 import re
 import logging
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # website: http://energy.gov/ig/

--- a/inspectors/epa.py
+++ b/inspectors/epa.py
@@ -59,10 +59,8 @@ def run(options):
   else:
     only = ALL_TOPIC_AREAS
 
-  index_body = utils.download(BASE_URL)
-
   current_year = None
-  index = BeautifulSoup(index_body)
+  index = utils.beautifulsoup_from_url(BASE_URL)
   tables = index.select('table.style1')
   if not tables:
     raise inspector.NoReportsFoundException("EPA")

--- a/inspectors/epa.py
+++ b/inspectors/epa.py
@@ -4,7 +4,6 @@ import datetime
 from urllib.parse import urljoin
 import re
 import os.path
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 archive = 1996

--- a/inspectors/exim.py
+++ b/inspectors/exim.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from utils import utils, inspector
-from bs4 import BeautifulSoup
 from bs4.element import Tag, NavigableString
 from datetime import datetime
 import os.path

--- a/inspectors/exim.py
+++ b/inspectors/exim.py
@@ -14,8 +14,7 @@ def run(options):
 
   published_on = None
   for page_url in [WHATS_NEW_URL, WHATS_NEW_ARCHIVE_URL, SEMIANNUAL_REPORTS_AND_TESTIMONIES_URL]:
-    body = utils.download(page_url)
-    doc = BeautifulSoup(body)
+    doc = utils.beautifulsoup_from_url(page_url)
 
     maincontent = doc.select("div#CS_Element_eximpagemaincontent")[0]
     all_a = maincontent.find_all("a")
@@ -89,8 +88,7 @@ def run(options):
 
   for page_url in [PRESS_RELEASES_URL, PRESS_RELEASES_ARCHIVE_URL]:
     done = False
-    body = utils.download(page_url)
-    doc = BeautifulSoup(body)
+    doc = utils.beautifulsoup_from_url(page_url)
 
     maincontent = doc.select("div#CS_Element_eximpagemaincontent")[0]
     all_p = maincontent.find_all("p")

--- a/inspectors/fca.py
+++ b/inspectors/fca.py
@@ -6,7 +6,6 @@ import os
 import re
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # https://www.fca.gov/home/inspector.html

--- a/inspectors/fca.py
+++ b/inspectors/fca.py
@@ -30,7 +30,7 @@ def run(options):
   year_range = inspector.year_range(options, archive)
 
   # Pull the general reports
-  doc = BeautifulSoup(utils.download(REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(REPORTS_URL)
   results = doc.select("div#mainContent li.mainContenttext a")
   if not results:
     raise inspector.NoReportsFoundError("Farm Credit Administration (reports)")
@@ -40,7 +40,7 @@ def run(options):
       inspector.save_report(report)
 
   # Pull the archive reports
-  doc = BeautifulSoup(utils.download(REPORT_ARCHIVE_URL))
+  doc = utils.beautifulsoup_from_url(REPORT_ARCHIVE_URL)
   results = doc.select("div#mainContent li.mainContenttext a") + doc.select("div#mainContent span.mainContenttext a")
   if not results:
     raise inspector.NoReportsFoundError("Farm Credit Administration (archive)")
@@ -52,7 +52,7 @@ def run(options):
       inspector.save_report(report)
 
   # Pull the semiannual reports
-  doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
   results = doc.select("div#mainContent li.mainContenttext a")
   if not results:
     raise inspector.NoReportsFoundError("Farm Credit Administration (semiannual reports)")

--- a/inspectors/fcc.py
+++ b/inspectors/fcc.py
@@ -30,7 +30,7 @@ def run(options):
   year_range = inspector.year_range(options, archive)
 
   for report_type, url in REPORT_URLS.items():
-    doc = beautifulsoup_from_url(url)
+    doc = utils.beautifulsoup_from_url(url)
     results = doc.find_all("table", {"border": 2})[0].select("tr")
     if not results:
       raise inspector.NoReportsFoundError("FCC (%s)" % report_type)
@@ -81,11 +81,5 @@ def report_from(result, page_url, report_type, year_range):
     'published_on': datetime.datetime.strftime(published_on, "%Y-%m-%d"),
   }
   return report
-
-
-def beautifulsoup_from_url(url):
-  body = utils.download(url)
-  return BeautifulSoup(body)
-
 
 utils.run(run) if (__name__ == "__main__") else None

--- a/inspectors/fcc.py
+++ b/inspectors/fcc.py
@@ -5,7 +5,6 @@ import logging
 import os
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://transition.fcc.gov/oig/oigreportsaudit.html

--- a/inspectors/fdic.py
+++ b/inspectors/fdic.py
@@ -5,7 +5,6 @@ import logging
 import os
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.fdicoig.gov

--- a/inspectors/fdic.py
+++ b/inspectors/fdic.py
@@ -32,7 +32,7 @@ def run(options):
   year_range = inspector.year_range(options, archive)
 
   # Pull the reports
-  doc = BeautifulSoup(utils.download(REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(REPORTS_URL)
   results = doc.find("table", {"cellpadding": "5"}).select("tr")
   if not results:
     raise inspector.NoReportsFoundError("FDIC")

--- a/inspectors/fec.py
+++ b/inspectors/fec.py
@@ -6,7 +6,6 @@ import os
 import re
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.fec.gov/fecig/fecig.shtml

--- a/inspectors/fec.py
+++ b/inspectors/fec.py
@@ -46,7 +46,7 @@ REPORT_PUBLISHED_MAPPING = {
 def run(options):
   year_range = inspector.year_range(options, archive)
 
-  doc = BeautifulSoup(utils.download(REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(REPORTS_URL)
 
   # Pull the audit reports
   audit_header = doc.find("a", attrs={"name": 'Audit Reports'})
@@ -102,7 +102,7 @@ def report_from(result, year_range, report_type, title_prefix=None):
     title = result.contents[0].strip().rstrip("-").strip()
   else:
     # Some pages have separate landing pages.
-    doc = BeautifulSoup(utils.download(report_url))
+    doc = utils.beautifulsoup_from_url(report_url)
     title = doc.select("h3")[1].text.strip()
     try:
       published_on_text = doc.select("h3")[2].text.strip()

--- a/inspectors/fed.py
+++ b/inspectors/fed.py
@@ -141,7 +141,7 @@ def semiannual_report_from(report_url, year_range):
     # If this is not a PDF, then it is actually a link to a landing page.
     # Grab the real report_url and the published date
     landing_url = report_url
-    landing_page = beautifulsoup_from_url(landing_url)
+    landing_page = utils.beautifulsoup_from_url(landing_url)
     report_url_relative = landing_page.select("div.report-header-container-aside a")[0].get('href')
     report_url = urljoin(BASE_PAGE_URL, report_url_relative)
 
@@ -174,10 +174,5 @@ def semiannual_report_from(report_url, year_range):
     'title': title,
     'published_on': datetime.datetime.strftime(published_on, "%Y-%m-%d"),
   }
-
-def beautifulsoup_from_url(url):
-  body = utils.download(url)
-  return BeautifulSoup(body)
-
 
 utils.run(run) if (__name__ == "__main__") else None

--- a/inspectors/fed.py
+++ b/inspectors/fed.py
@@ -5,7 +5,6 @@ import logging
 import os
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://oig.federalreserve.gov/reports/allyearsboardcfpb.htm

--- a/inspectors/fed.py
+++ b/inspectors/fed.py
@@ -49,7 +49,7 @@ def run(options):
   year_range = inspector.year_range(options, archive)
 
   # Pull the audit reports
-  doc = beautifulsoup_from_url(REPORTS_URL)
+  doc = utils.beautifulsoup_from_url(REPORTS_URL)
   results = doc.select("#rounded-corner > tr")
   if not results:
     raise inspector.NoReportsFoundError("Federal Reserve (audit reports)")
@@ -59,7 +59,7 @@ def run(options):
       inspector.save_report(report)
 
   # Pull the semiannual reports
-  doc = beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
+  doc = utils.beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
   results = doc.select("div.style-aside ul > li > a")
   if not results:
     raise inspector.NoReportsFoundError("Federal Reserve (semiannual reports)")
@@ -88,7 +88,7 @@ def report_from(result, year_range):
     return
 
   logging.debug("Scraping landing url: %s", landing_url)
-  landing_page = beautifulsoup_from_url(landing_url)
+  landing_page = utils.beautifulsoup_from_url(landing_url)
 
   landing_page_text = landing_page.select("div.style-report-text")[0].text
 

--- a/inspectors/fhfa.py
+++ b/inspectors/fhfa.py
@@ -4,7 +4,6 @@ import datetime
 import logging
 import os
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://fhfaoig.gov/

--- a/inspectors/fhfa.py
+++ b/inspectors/fhfa.py
@@ -39,7 +39,7 @@ def run(options):
 
   # Pull the audit reports. Pages are 0-indexed.
   for page in range(0, int(pages) - 1):
-    doc = BeautifulSoup(utils.download(AUDIT_REPORTS_URL.format(page=page)))
+    doc = utils.beautifulsoup_from_url(AUDIT_REPORTS_URL.format(page=page))
     results = doc.select("span.field-content")
     if not results:
       if page == 0:
@@ -55,7 +55,7 @@ def run(options):
 
   # Grab the other reports
   for report_type, url in OTHER_REPORT_URLS.items():
-    doc = BeautifulSoup(utils.download(url))
+    doc = utils.beautifulsoup_from_url(url)
     results = doc.select(".views-field")
     if not results:
       results = doc.select(".views-row")

--- a/inspectors/flra.py
+++ b/inspectors/flra.py
@@ -5,7 +5,6 @@ import logging
 import os
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # https://www.flra.gov/OIG

--- a/inspectors/flra.py
+++ b/inspectors/flra.py
@@ -36,7 +36,7 @@ def run(options):
 
   # Pull the reports
   for report_type, url in REPORT_URLS.items():
-    doc = BeautifulSoup(utils.download(url))
+    doc = utils.beautifulsoup_from_url(url)
     results = doc.select("div.node ul li")
     if not results:
       raise inspector.NoReportsFoundError("Federal Labor Relations Authority (%s)" % report_type)

--- a/inspectors/fmc.py
+++ b/inspectors/fmc.py
@@ -6,7 +6,6 @@ import os
 import re
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.fmc.gov/bureaus_offices/office_of_inspector_general.aspx

--- a/inspectors/fmc.py
+++ b/inspectors/fmc.py
@@ -44,7 +44,7 @@ def run(options):
   year_range = inspector.year_range(options, archive)
 
   # Pull the audit reports
-  doc = BeautifulSoup(utils.download(AUDIT_REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(AUDIT_REPORTS_URL)
   results = doc.select("table tr")
   if not results:
     raise inspector.NoReportsFoundError("Federal Maritime Commission (audits)")
@@ -60,7 +60,7 @@ def run(options):
   audit_year_links = doc.select("div.col-2-3 ul li a")
   for year_link in audit_year_links:
     audit_year_url = urljoin(AUDIT_REPORTS_URL, year_link.get('href'))
-    doc = BeautifulSoup(utils.download(audit_year_url))
+    doc = utils.beautifulsoup_from_url(audit_year_url)
     results = doc.select("table tr")
     if not results:
       # Grab results other than first and last (header and extra links)
@@ -76,7 +76,7 @@ def run(options):
         inspector.save_report(report)
 
   # Pull the semiannual reports
-  doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
   results = doc.select("div.col-2-2 p a") + doc.select("div.col-2-2 li a")
   if not results:
     raise inspector.NoReportsFoundError("Federal Maritime Commission (semiannual reports)")

--- a/inspectors/ftc.py
+++ b/inspectors/ftc.py
@@ -31,7 +31,7 @@ def run(options):
 
   # Pull the audit reports
   for report_type, url in REPORT_URLS.items():
-    doc = BeautifulSoup(utils.download(url))
+    doc = utils.beautifulsoup_from_url(url)
     results = doc.select("li.views-row")
     if not results:
       raise inspector.NoReportsFoundError("FTC (%s)" % report_type)

--- a/inspectors/ftc.py
+++ b/inspectors/ftc.py
@@ -6,7 +6,6 @@ import os
 import re
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.ftc.gov/about-ftc/office-inspector-general

--- a/inspectors/gao.py
+++ b/inspectors/gao.py
@@ -25,7 +25,7 @@ def run(options):
 
   # Pull the audit and semiannual reports
   for reports_url in [REPORTS_URL, SEMIANNUAL_REPORTS_URL]:
-    doc = beautifulsoup_from_url(reports_url)
+    doc = utils.beautifulsoup_from_url(reports_url)
     results = doc.select("div.listing")
     if not results:
       raise inspector.NoReportsFoundError("GAO (%s)" % reports_url)
@@ -48,7 +48,7 @@ def report_from(result, year_range):
     return
 
   logging.debug("Scraping landing url: %s", landing_url)
-  landing_page = beautifulsoup_from_url(landing_url)
+  landing_page = utils.beautifulsoup_from_url(landing_url)
   summary = landing_page.select("div.left_col")[0].text.strip()
 
   pdf_link = landing_page.select("#link_bar > a")[0]
@@ -71,10 +71,6 @@ def report_from(result, year_range):
     'published_on': datetime.datetime.strftime(published_on, "%Y-%m-%d"),
   }
   return report
-
-def beautifulsoup_from_url(url):
-  body = utils.download(url)
-  return BeautifulSoup(body)
 
 
 utils.run(run) if (__name__ == "__main__") else None

--- a/inspectors/gao.py
+++ b/inspectors/gao.py
@@ -4,7 +4,6 @@ import datetime
 import logging
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.gao.gov/about/workforce/ig_reports.html

--- a/inspectors/gpo.py
+++ b/inspectors/gpo.py
@@ -35,7 +35,7 @@ def run(options):
 
   # Pull the reports
   for report_type, url in REPORT_URLS.items():
-    doc = BeautifulSoup(utils.download(url))
+    doc = utils.beautifulsoup_from_url(url)
     results = doc.select("div.section1 div.ltext > table tr")
     if not results:
       results = doc.select("td.three-col-layout-middle div.ltext > table tr")

--- a/inspectors/gpo.py
+++ b/inspectors/gpo.py
@@ -5,7 +5,6 @@ import logging
 import re
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.gpo.gov/oig/

--- a/inspectors/gsa.py
+++ b/inspectors/gsa.py
@@ -146,7 +146,7 @@ DATE_RE = re.compile("(January|February|March|April|May|June|July|August|" +
 DATE_RE_MM_DD_YY = re.compile("[0-9]?[0-9]/[0-9]?[0-9]/[0-9][0-9]")
 
 HARDCODED_DATES = {
-   "Hats Off Program Investigative Report": "June 16, 2011",
+  "Hats Off Program Investigative Report": "June 16, 2011",
   "Major Issues from Fiscal Year 2010 Multiple Award Schedule Preaward Audits": "September 26, 2011",
   "Review of Center for Information Security Services FTS": "March 23, 2001",
   "Audit of Procurement of Profesional Services from the FSS Multiple Award Schedules": "July 31, 2003",

--- a/inspectors/gsa.py
+++ b/inspectors/gsa.py
@@ -26,9 +26,7 @@ def crawl_index(base_url, options, is_meta_index=False):
   done = False
   while not done:
     url = url_for(base_url, page)
-    body = utils.download(url)
-
-    doc = BeautifulSoup(body)
+    doc = utils.beautifulsoup_from_url(url)
 
     next_page = page + 1
     found_next_page = False
@@ -148,7 +146,7 @@ DATE_RE = re.compile("(January|February|March|April|May|June|July|August|" +
 DATE_RE_MM_DD_YY = re.compile("[0-9]?[0-9]/[0-9]?[0-9]/[0-9][0-9]")
 
 HARDCODED_DATES = {
-  "Hats Off Program Investigative Report": "June 16, 2011",
+   "Hats Off Program Investigative Report": "June 16, 2011",
   "Major Issues from Fiscal Year 2010 Multiple Award Schedule Preaward Audits": "September 26, 2011",
   "Review of Center for Information Security Services FTS": "March 23, 2001",
   "Audit of Procurement of Profesional Services from the FSS Multiple Award Schedules": "July 31, 2003",

--- a/inspectors/gsa.py
+++ b/inspectors/gsa.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from utils import utils, inspector
-from bs4 import BeautifulSoup
 from datetime import datetime
 import re
 import logging

--- a/inspectors/hhs.py
+++ b/inspectors/hhs.py
@@ -667,7 +667,7 @@ def beautifulsoup_from_url(url):
   body = utils.download(url)
   if body is None: return None
 
-  doc = BeautifulSoup(body)
+  doc = BeautifulSoup(body, "lxml")
 
   # Some of the pages will return meta refreshes
   if doc.find("meta") and doc.find("meta").attrs.get('http-equiv') == 'REFRESH':

--- a/inspectors/house.py
+++ b/inspectors/house.py
@@ -5,7 +5,6 @@ import re
 import logging
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://house.gov/content/learn/officers_and_organizations/inspector_general.php

--- a/inspectors/house.py
+++ b/inspectors/house.py
@@ -40,7 +40,7 @@ def run(options):
 
   # Pull the reports
   for url in [IG_URL]:
-    doc = BeautifulSoup(utils.download(url))
+    doc = utils.beautifulsoup_from_url(url)
     results = doc.select("div.relatedContent ul.links li a")
     if not results:
       raise inspector.NoReportsFoundError("House of Representatives (%s)" % url)

--- a/inspectors/hud.py
+++ b/inspectors/hud.py
@@ -160,8 +160,7 @@ def run(options):
     logging.debug("## Downloading page %i" % page)
 
     url = url_for(year_range, page=page)
-    index_body = utils.download(url)
-    index = BeautifulSoup(index_body)
+    index = utils.beautifulsoup_from_url(url)
 
     rows = index.select('div.views-row')
 
@@ -192,8 +191,7 @@ def run(options):
         continue
     inspector.save_report(report)
 
-  archives_body = utils.download(ARCHIVES_URL)
-  archives_page = BeautifulSoup(archives_body)
+  archives_page = utils.beautifulsoup_from_url(ARCHIVES_URL)
   state_links = archives_page.find("table", {"bgcolor": "CCCCCC"}). \
       table.find_all("a")
   if not state_links:
@@ -202,8 +200,7 @@ def run(options):
     relative_url = state_link.get('href')
     state_name = state_link.text.strip()
     state_url = urljoin(ARCHIVES_URL, relative_url)
-    state_body = utils.download(state_url)
-    state_page = BeautifulSoup(state_body)
+    state_page = utils.beautifulsoup_from_url(state_url)
     state_container = state_page.h2.parent
 
     # N.B. split_dom is guaranteed to yield at least one element. If the
@@ -287,8 +284,7 @@ def report_from(report_row, year_range):
 
   logging.debug("### Processing report %s" % landing_url)
 
-  report_page_body = utils.download(landing_url)
-  report_page = BeautifulSoup(report_page_body)
+  report_page = utils.beautifulsoup_from_url(landing_url)
 
   article = report_page.select('article')[0]
 

--- a/inspectors/hud.py
+++ b/inspectors/hud.py
@@ -5,7 +5,7 @@ import logging
 import os
 import re
 from urllib.parse import urljoin
-from bs4 import BeautifulSoup, Tag, NavigableString
+from bs4 import Tag, NavigableString
 from utils import utils, inspector
 
 archive = 2001

--- a/inspectors/interior.py
+++ b/inspectors/interior.py
@@ -37,7 +37,7 @@ def run(options):
   year_range = inspector.year_range(options, archive)
 
   response = utils.scraper.post(REPORT_SEARCH_URL, data=POST_DATA)
-  doc = BeautifulSoup(response.text)
+  doc = BeautifulSoup(response.text, "lxml")
 
   results = doc.select("div.report")
   if not results:

--- a/inspectors/itc.py
+++ b/inspectors/itc.py
@@ -4,7 +4,6 @@ import datetime
 import logging
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.usitc.gov/oig/

--- a/inspectors/itc.py
+++ b/inspectors/itc.py
@@ -32,7 +32,7 @@ def run(options):
   year_range = inspector.year_range(options, archive)
 
   # Pull the audit reports
-  doc = BeautifulSoup(utils.download(AUDIT_REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(AUDIT_REPORTS_URL)
 
   headers = doc.select("p.Ptitle1")
   if not headers:

--- a/inspectors/labor.py
+++ b/inspectors/labor.py
@@ -5,7 +5,6 @@ import logging
 import os
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.oig.dol.gov/auditreports.htm

--- a/inspectors/labor.py
+++ b/inspectors/labor.py
@@ -44,7 +44,7 @@ def run(options):
         pre_1998_done = True
     for page_number in range(0, 10000):
       year_url = url_for(year, page_number)
-      doc = beautifulsoup_from_url(year_url)
+      doc = utils.beautifulsoup_from_url(year_url)
       results = doc.select("ol li")
       if not results:
         if page_number == 0:
@@ -57,7 +57,7 @@ def run(options):
           inspector.save_report(report)
 
   # Pull the semiannual reports
-  doc = beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
+  doc = utils.beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
   results = doc.select("#content + div p a")
   if not results:
     raise inspector.NoReportsFoundError("Department of Labor (semiannal reports)")
@@ -162,11 +162,5 @@ def url_for(year, page_number):
   if year < 1998:  # Everything before 1998 is clumped together
     year = "pre_1998"
   return AUDIT_REPORTS_URL.format("{}&next_i={}".format(year, offset))
-
-
-def beautifulsoup_from_url(url):
-  body = utils.download(url)
-  return BeautifulSoup(body)
-
 
 utils.run(run) if (__name__ == "__main__") else None

--- a/inspectors/loc.py
+++ b/inspectors/loc.py
@@ -5,7 +5,6 @@ import logging
 from urllib.parse import urljoin
 import re
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # https://www.loc.gov/about/office-of-the-inspector-general/

--- a/inspectors/loc.py
+++ b/inspectors/loc.py
@@ -76,7 +76,7 @@ class LibraryOfCongressScraper(object):
     # This page contains semianual reports as well as a few Audit reports for
     # Fiscal Year 2014 and links to sub-pages that contain links for other
     # fiscal years.
-    doc = BeautifulSoup(utils.download(REPORTS_BY_YEAR_URL))
+    doc = utils.beautifulsoup_from_url(REPORTS_BY_YEAR_URL)
 
     # Get the semiannual reports to Congress.
     self.get_semiannual_reports_to_congress(doc)
@@ -90,14 +90,14 @@ class LibraryOfCongressScraper(object):
       link = li.find('a')
       if link:
         next_url = urljoin(REPORTS_BY_YEAR_URL, link['href'])
-        doc = BeautifulSoup(utils.download(next_url))
+        doc = utils.beautifulsoup_from_url(next_url)
         uls = self.get_uls_past_audit_header(doc)
         assert len(uls) == 1, ('Mysterious additional ul data on page: %s' %
                                next_url)
         self.get_bare_reports(uls[0])
 
   def get_listed_reports(self, url):
-    doc = BeautifulSoup(utils.download(url))
+    doc = utils.beautifulsoup_from_url(url)
     article = doc.select('.article')[0]
     results = article.find_all('ul')
     if not results:

--- a/inspectors/lsc.py
+++ b/inspectors/lsc.py
@@ -6,7 +6,7 @@ import os
 import re
 from urllib.parse import urljoin, unquote
 
-from bs4 import BeautifulSoup, Tag, NavigableString, Comment
+from bs4 import Tag, NavigableString, Comment
 from utils import utils, inspector
 
 # https://www.oig.lsc.gov

--- a/inspectors/lsc.py
+++ b/inspectors/lsc.py
@@ -174,8 +174,7 @@ def run(options):
 
   # Pull the audit reports
   for url, report_type, parse_func in REPORT_PAGES_INFO:
-    page_content = utils.download(url)
-    doc = BeautifulSoup(page_content)
+    doc = utils.beautifulsoup_from_url(url)
 
     content = doc.select("section.article-content")[0]
     parse_func(content, url, report_type, year_range)

--- a/inspectors/nasa.py
+++ b/inspectors/nasa.py
@@ -5,7 +5,6 @@ import logging
 import os
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://oig.nasa.gov/

--- a/inspectors/nasa.py
+++ b/inspectors/nasa.py
@@ -29,7 +29,7 @@ def run(options):
   # Pull the audit reports
   for year in year_range:
     url = AUDITS_REPORTS_URL.format(str(year)[2:4])
-    doc = BeautifulSoup(utils.download(url))
+    doc = utils.beautifulsoup_from_url(url)
     results = doc.select("tr")
     if not results:
       raise inspector.NoReportsFoundError("NASA (%d)" % year)
@@ -42,7 +42,7 @@ def run(options):
         inspector.save_report(report)
 
   # Pull the other reports
-  doc = BeautifulSoup(utils.download(OTHER_REPORT_URL))
+  doc = utils.beautifulsoup_from_url(OTHER_REPORT_URL)
   results = doc.select("#subContainer ul li")
   if not results:
     raise inspector.NoReportsFoundError("NASA (other)")

--- a/inspectors/ncua.py
+++ b/inspectors/ncua.py
@@ -6,7 +6,6 @@ import os
 import re
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.ncua.gov/about/Leadership/Pages/page_oig.aspx
@@ -32,7 +31,7 @@ def run(options):
     doc = utils.beautifulsoup_from_url(AUDIT_REPORTS_URL.format(year=year))
 
     # if it's a 404 page (200 response code), move on
-    if not_found(doc):
+    if doc == None or not_found(doc):
       continue
 
     results = doc.select("div.content table tr")

--- a/inspectors/ncua.py
+++ b/inspectors/ncua.py
@@ -29,7 +29,7 @@ def run(options):
   for year in year_range:
     if year < 2002:  # The oldest page for audit reports
       continue
-    doc = BeautifulSoup(utils.download(AUDIT_REPORTS_URL.format(year=year)))
+    doc = utils.beautifulsoup_from_url(AUDIT_REPORTS_URL.format(year=year))
 
     # if it's a 404 page (200 response code), move on
     if not_found(doc):
@@ -47,7 +47,7 @@ def run(options):
         inspector.save_report(report)
 
   # Pull the other reports
-  doc = BeautifulSoup(utils.download(OTHER_REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(OTHER_REPORTS_URL)
   results = doc.select("div.content li")
   if not results:
     raise inspector.NoReportsFoundError("NCUA (other)")
@@ -57,7 +57,7 @@ def run(options):
       inspector.save_report(report)
 
   # Pull the semiannual reports
-  doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
   results = doc.select("div.content a")
   if not results:
     raise inspector.NoReportsFoundError("NCUA (semiannual reports)")

--- a/inspectors/nea.py
+++ b/inspectors/nea.py
@@ -44,7 +44,7 @@ def run(options):
 
   # Pull the reports
   for report_type, url in REPORT_URLS.items():
-    doc = BeautifulSoup(utils.download(url))
+    doc = utils.beautifulsoup_from_url(url)
     results = doc.select("div.field-item li")
     if not results:
       results = doc.select("div.field-item tr")

--- a/inspectors/nea.py
+++ b/inspectors/nea.py
@@ -6,7 +6,6 @@ import os
 import re
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://arts.gov/oig

--- a/inspectors/neh.py
+++ b/inspectors/neh.py
@@ -5,7 +5,6 @@ import logging
 import os
 import re
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.neh.gov/about/oig

--- a/inspectors/neh.py
+++ b/inspectors/neh.py
@@ -24,7 +24,7 @@ def run(options):
   year_range = inspector.year_range(options, archive)
 
   # Pull the audit reports
-  doc = BeautifulSoup(utils.download(AUDIT_REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(AUDIT_REPORTS_URL)
   results = doc.select("table.views-table tr")
   if not results:
     raise inspector.NoReportsFoundError("National Endowment for the Humanities (audit reports)")
@@ -34,7 +34,7 @@ def run(options):
       inspector.save_report(report)
 
   # Pull the semiannual reports
-  doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
   results = doc.select("table.views-table tr")
   if not results:
     raise inspector.NoReportsFoundError("National Endowment for the Humanities (semiannual reports)")

--- a/inspectors/nlrb.py
+++ b/inspectors/nlrb.py
@@ -54,7 +54,7 @@ def run(options):
 
   # Pull the audit and inspections reports
   for report_type, reports_url in REPORT_URLS:
-    doc = BeautifulSoup(utils.download(reports_url))
+    doc = utils.beautifulsoup_from_url(reports_url)
     results = doc.select("div.field-item")
     if not results:
       raise inspector.NoReportsFoundError("National Labor Relations Board (%s)" % report_type)
@@ -64,7 +64,7 @@ def run(options):
         inspector.save_report(report)
 
   # Pull the semiannual reports
-  doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
   results = doc.select("div.field-item")
   if not results:
     raise inspector.NoReportsFoundError("National Labor Relations Board (semiannual reports)")

--- a/inspectors/nlrb.py
+++ b/inspectors/nlrb.py
@@ -6,7 +6,6 @@ import os
 import re
 import urllib
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # https://www.nlrb.gov/who-we-are/inspector-general

--- a/inspectors/nrc.py
+++ b/inspectors/nrc.py
@@ -6,7 +6,6 @@ import os
 import re
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.nrc.gov/insp-gen.html

--- a/inspectors/nrc.py
+++ b/inspectors/nrc.py
@@ -52,7 +52,7 @@ def run(options):
   # Pull the audit reports
   for year in year_range:
     url = AUDITS_REPORTS_URL.format(year)
-    doc = BeautifulSoup(utils.download(url))
+    doc = utils.beautifulsoup_from_url(url)
     results = doc.find("table", border="1").select("tr")
     if not results:
       raise inspector.NoReportsFoundError("Nuclear Regulatory Commission (%d)" % year)
@@ -65,7 +65,7 @@ def run(options):
         inspector.save_report(report)
 
   # Pull the congressional testimony
-  doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
   semiannual_reports_table = doc.find("table", border="1")
   results = semiannual_reports_table.select("tr")
   if not results:
@@ -80,7 +80,7 @@ def run(options):
 
   # Pull the other reports
   for reports_url, id_prefix in OTHER_REPORT_URLS:
-    doc = BeautifulSoup(utils.download(reports_url))
+    doc = utils.beautifulsoup_from_url(reports_url)
     results = doc.find("table", border="1").select("tr")
     if not results:
       raise inspector.NoReportsFoundError("Nuclear Regulatory Commission (other)")
@@ -156,7 +156,7 @@ def semiannual_report_from(result, year_range):
   report_link = result.find("a")
   landing_url = urljoin(SEMIANNUAL_REPORTS_URL, report_link.get('href'))
 
-  landing_page = BeautifulSoup(utils.download(landing_url))
+  landing_page = utils.beautifulsoup_from_url(landing_url)
   title = " ".join(landing_page.select("#mainSubFull h1")[0].text.split())
 
   try:

--- a/inspectors/nsf.py
+++ b/inspectors/nsf.py
@@ -44,7 +44,7 @@ def run(options):
   year_range = inspector.year_range(options, archive)
 
   # Pull the audit reports
-  doc = BeautifulSoup(utils.download(AUDIT_REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(AUDIT_REPORTS_URL)
   results = doc.select("td.text table tr")
   if not results:
     raise inspector.NoReportsFoundError("National Science Foundation (audit reports")
@@ -57,7 +57,7 @@ def run(options):
       inspector.save_report(report)
 
   # Pull the semiannual reports
-  doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
   results = doc.select("td.text table tr")
   if not results:
     raise inspector.NoReportsFoundError("National Science Foundation (semiannual reports)")
@@ -73,7 +73,7 @@ def run(options):
     url=CASE_REPORTS_URL,
     data=CASE_REPORTS_DATA,
   )
-  doc = BeautifulSoup(response.content)
+  doc = BeautifulSoup(response.content, "lxml")
   results = doc.select("td.text table tr")
   if not results:
     raise inspector.NoReportsFoundError("National Science Foundation (case reports)")
@@ -85,7 +85,7 @@ def run(options):
       inspector.save_report(report)
 
   # Pull the testimony
-  doc = BeautifulSoup(utils.download(TESTIMONY_REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(TESTIMONY_REPORTS_URL)
   results = doc.select("td.text table tr")
   if not results:
     raise inspector.NoReportsFoundError("National Science Foundation (testimony)")
@@ -191,7 +191,7 @@ def semiannual_report_from(result, year_range):
     landing_page_response = utils.scraper.get(landing_url)
     landing_url = landing_page_response.url
 
-    landing_page = BeautifulSoup(landing_page_response.content)
+    landing_page = BeautifulSoup(landing_page_response.content, "lxml")
     report_leadin_text = landing_page.find(text=REPORT_LEADIN_TEXT)
     report_link_text = landing_page.find(text=REPORT_LINK_TEXT)
     report_link = None

--- a/inspectors/opm.py
+++ b/inspectors/opm.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from utils import utils, inspector
-from bs4 import BeautifulSoup
 import bs4
 import os
 import logging

--- a/inspectors/opm.py
+++ b/inspectors/opm.py
@@ -35,9 +35,7 @@ def run(options):
   logging.info("## Downloading reports from %i to %i" % (year_range[0], year_range[-1]))
 
   url = url_for()
-  body = utils.download(url)
-
-  doc = BeautifulSoup(body)
+  doc = utils.beautifulsoup_from_url(url)
   results = doc.select("section")
   if not results:
     raise inspector.NoReportsFoundError("OPM")

--- a/inspectors/pbgc.py
+++ b/inspectors/pbgc.py
@@ -41,7 +41,7 @@ def run(options):
     if year < 1998:  # The earliest year for audit reports
       continue
     year_url = AUDIT_REPORTS_URL.format(year=year)
-    doc = BeautifulSoup(utils.download(year_url))
+    doc = utils.beautifulsoup_from_url(year_url)
     results = doc.select("tr")
     if not results:
       raise inspector.NoReportsFoundError("Pension Benefit Guaranty Corporation (audit reports)")
@@ -51,7 +51,7 @@ def run(options):
         inspector.save_report(report)
 
   # Pull the congressional requests
-  doc = BeautifulSoup(utils.download(CONGRESSIONAL_REQUESTS_URL))
+  doc = utils.beautifulsoup_from_url(CONGRESSIONAL_REQUESTS_URL)
   results = doc.select("tr")
   if not results:
     raise inspector.NoReportsFoundError("Pension Benefit Guaranty Corporation (congressional requests)")
@@ -61,7 +61,7 @@ def run(options):
       inspector.save_report(report)
 
   # Pull the semiannual reports
-  doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
   results =  doc.select("div.holder a")
   if not results:
     raise inspector.NoReportsFoundError("Pension Benefit Guaranty Corporation (semiannual reports)")
@@ -71,7 +71,7 @@ def run(options):
       inspector.save_report(report)
 
   # Pull the congressional testimony
-  doc = BeautifulSoup(utils.download(CONGRESSIONAL_TESTIMONY_URL))
+  doc = utils.beautifulsoup_from_url(CONGRESSIONAL_TESTIMONY_URL)
   results =  doc.select("div.holder a")
   if not results:
     raise inspector.NoReportsFoundError("Pension Benefit Guaranty Corporation (congressional testimony)")
@@ -112,7 +112,7 @@ def report_from(result, report_type, year_range):
     landing_url = None
     summary = None
   else:
-    landing_page = BeautifulSoup(utils.download(landing_url))
+    landing_page = utils.beautifulsoup_from_url(landing_url)
     summary = " ".join(landing_page.select("div.holder")[0].text.split())
     report_link = landing_page.find("a", href=PDF_REGEX)
     if report_link:
@@ -159,7 +159,7 @@ def semiannual_report_from(result, year_range):
   report_id_javascript = result.get('onclick')
   report_id = re.search("'(.*)'", report_id_javascript).groups()[0]
   landing_url  = "http://oig.pbgc.gov/sarc/{report_id}.html".format(report_id=report_id)
-  landing_page = BeautifulSoup(utils.download(landing_url))
+  landing_page = utils.beautifulsoup_from_url(landing_url)
 
   title = " ".join(landing_page.select("h3")[0].text.split())
   relative_report_url = landing_page.find("a", text="Read Full Report").get('href')

--- a/inspectors/pbgc.py
+++ b/inspectors/pbgc.py
@@ -6,7 +6,6 @@ import os
 import re
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://oig.pbgc.gov/

--- a/inspectors/peacecorps.py
+++ b/inspectors/peacecorps.py
@@ -5,7 +5,6 @@ import logging
 import os
 import urllib
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.peacecorps.gov/about/inspgen/

--- a/inspectors/peacecorps.py
+++ b/inspectors/peacecorps.py
@@ -60,7 +60,7 @@ def run(options):
   year_range = inspector.year_range(options, archive)
 
   # Pull the reports
-  doc = BeautifulSoup(utils.download(REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(REPORTS_URL)
   results = doc.select("li div li")
   if not results:
     raise inspector.NoReportsFoundError("Peace Corps")

--- a/inspectors/prc.py
+++ b/inspectors/prc.py
@@ -3,7 +3,6 @@
 import datetime
 import logging
 import os
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 archive = 2007

--- a/inspectors/prc.py
+++ b/inspectors/prc.py
@@ -20,13 +20,12 @@ def run(options):
   year_range = inspector.year_range(options, archive)
 
   # Find the number of pages to iterate
-  doc = BeautifulSoup(utils.download(REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(REPORTS_URL)
   page_count = int(doc.select("li.pager-last a")[0]['href'][-1:])
 
   # Iterate over those pages
   for page in range(0, page_count + 1):
-    response = utils.download(REPORTS_URL + str(page))
-    doc = BeautifulSoup(response)
+    doc = utils.beautifulsoup_from_url(REPORTS_URL + str(page))
     results = doc.select(".reports")
     if not results:
       if page == 0:

--- a/inspectors/rrb.py
+++ b/inspectors/rrb.py
@@ -23,7 +23,7 @@ AUDIT_REPORTS_URL = "http://www.rrb.gov/oig/reports/FY{year}reports.asp"
 def run(options):
   year_range = inspector.year_range(options, archive)
 
-  doc = BeautifulSoup(utils.download(REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(REPORTS_URL)
 
   # Pull the semiannual reports
   semiannul_results = doc.select("#AnnualManagementReports select")[0]
@@ -47,7 +47,7 @@ def run(options):
     if year < 2001:  # The oldest fiscal year page available
       continue
     year_url = AUDIT_REPORTS_URL.format(year=year)
-    doc = BeautifulSoup(utils.download(year_url))
+    doc = utils.beautifulsoup_from_url(year_url)
     results = doc.select("#main table tr")
     if not results:
       raise inspector.NoReportsFoundError("Railroad Retirement Board (%d)" % year)

--- a/inspectors/rrb.py
+++ b/inspectors/rrb.py
@@ -5,7 +5,6 @@ import logging
 import os
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.rrb.gov/oig/Default.asp

--- a/inspectors/sba.py
+++ b/inspectors/sba.py
@@ -117,7 +117,7 @@ def beautifulsoup_from_page_index(page):
     raise Exception("Failed to fetch data from sba.gov.")
 
   page_html = response.json()[1]['data']
-  return BeautifulSoup(page_html)
+  return BeautifulSoup(page_html, "lxml")
 
 def get_last_page_index():
   doc = beautifulsoup_from_page_index(0)
@@ -182,7 +182,7 @@ def report_from(result, year_range):
     logging.warn("Bad landing URL, downloaded None: %s" % landing_url)
     raise Exception("Couldn't download landing URL.")
 
-  landing_page = BeautifulSoup(landing_body)
+  landing_page = BeautifulSoup(landing_body, "lxml")
 
   try:
     report_url = urljoin(BASE_REPORT_URL, landing_page.select("#attachments a")[0].get('href'))

--- a/inspectors/sec.py
+++ b/inspectors/sec.py
@@ -6,7 +6,6 @@ import os
 import re
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.sec.gov/about/offices/oig/inspector_general_reppubs_testimony.shtml

--- a/inspectors/sec.py
+++ b/inspectors/sec.py
@@ -163,8 +163,7 @@ def run(options):
 
   for topic in topics:
     topic_url = TOPIC_TO_URL[topic]
-    body = utils.download(topic_url)
-    doc = BeautifulSoup(body)
+    doc = utils.beautifulsoup_from_url(topic_url)
 
     try:
       year_results = doc.select("#Listing")[0]

--- a/inspectors/sigar.py
+++ b/inspectors/sigar.py
@@ -5,7 +5,6 @@ import logging
 import os
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.sigar.mil/

--- a/inspectors/sigar.py
+++ b/inspectors/sigar.py
@@ -40,7 +40,7 @@ def run(options):
 
   # Pull the reports
   for report_type, report_url in REPORT_URLS.items():
-    doc = BeautifulSoup(utils.download(report_url))
+    doc = utils.beautifulsoup_from_url(report_url)
     results = doc.select("item")
     if not results:
       raise inspector.NoReportsFoundError("SIGAR (%s)" % report_type)

--- a/inspectors/sigtarp.py
+++ b/inspectors/sigtarp.py
@@ -4,7 +4,6 @@ import datetime
 import logging
 import os
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.sigtarp.gov

--- a/inspectors/sigtarp.py
+++ b/inspectors/sigtarp.py
@@ -28,7 +28,7 @@ def run(options):
 
   # Pull the reports
   for report_type, report_url in REPORT_URLS.items():
-    doc = BeautifulSoup(utils.download(report_url))
+    doc = utils.beautifulsoup_from_url(report_url)
     results =  doc.select("td.mainInner div.ms-WPBody li")
 
     if not results:

--- a/inspectors/smithsonian.py
+++ b/inspectors/smithsonian.py
@@ -6,7 +6,6 @@ import os
 import re
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.si.edu/OIG

--- a/inspectors/smithsonian.py
+++ b/inspectors/smithsonian.py
@@ -62,7 +62,7 @@ def run(options):
   year_range = inspector.year_range(options, archive)
 
   # # Pull the RSS feed
-  doc = BeautifulSoup(utils.download(RSS_URL))
+  doc = utils.beautifulsoup_from_url(RSS_URL)
   results = doc.select("item")
   if not results:
     raise inspector.NoReportsFoundError("Smithsonian (RSS)")
@@ -72,7 +72,7 @@ def run(options):
       inspector.save_report(report)
 
   # # Pull the recent audit reports.
-  doc = BeautifulSoup(utils.download(RECENT_AUDITS_URL))
+  doc = utils.beautifulsoup_from_url(RECENT_AUDITS_URL)
   results = doc.select("div.block > a")
   if not results:
     raise inspector.NoReportsFoundError("Smithsonian (recent audit reports)")
@@ -82,7 +82,7 @@ def run(options):
       inspector.save_report(report)
 
   # Pull the archive audit reports
-  doc = BeautifulSoup(utils.download(AUDIT_ARCHIVE_URL))
+  doc = utils.beautifulsoup_from_url(AUDIT_ARCHIVE_URL)
   results = doc.select("div.block a")
   if not results:
     raise inspector.NoReportsFoundError("Smithsonian (audit archive)")
@@ -92,7 +92,7 @@ def run(options):
       inspector.save_report(report)
 
   # Pull the other reports
-  doc = BeautifulSoup(utils.download(OTHER_REPORTS_URl))
+  doc = utils.beautifulsoup_from_url(OTHER_REPORTS_URl)
   results = doc.select("div.block > a")
   if not results:
     raise inspector.NoReportsFoundError("Smithsonian (other)")
@@ -181,7 +181,7 @@ def report_from(result, year_range):
   summary = None
   if not report_url.endswith(".pdf"):
     # Some reports link to other page which link to the full report
-    report_page = BeautifulSoup(utils.download(report_url))
+    report_page = utils.beautifulsoup_from_url(report_url)
     relative_report_url = report_page.select("div.block a")[0].get('href')
     report_url = urljoin(report_url, relative_report_url)
     # Strip extra path adjustments

--- a/inspectors/ssa.py
+++ b/inspectors/ssa.py
@@ -63,7 +63,7 @@ def run(options):
 
 def reports_from_page(url_format, page, report_type, year_range, year=''):
   url = url_format.format(page=page, year=year)
-  doc = BeautifulSoup(utils.download(url))
+  doc = utils.beautifulsoup_from_url(url)
   results = doc.select("td.views-field")
   if not results:
     results = doc.select("div.views-row")
@@ -114,7 +114,7 @@ def report_from(result, report_type, year_range):
         "applications-0":
     report_id = "A-07-10-20166"
 
-  landing_page = BeautifulSoup(utils.download(landing_url))
+  landing_page = utils.beautifulsoup_from_url(landing_url)
 
   unreleased = False
   if "Limited Distribution" in title:

--- a/inspectors/ssa.py
+++ b/inspectors/ssa.py
@@ -5,7 +5,6 @@ import logging
 import os
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://oig.ssa.gov/

--- a/inspectors/state.py
+++ b/inspectors/state.py
@@ -4,7 +4,6 @@ import datetime
 import logging
 import os
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # https://oig.state.gov/reports

--- a/inspectors/state.py
+++ b/inspectors/state.py
@@ -52,8 +52,7 @@ def run(options):
       break
 
 def extract_reports_for_page(url, page_number, year_range, listing_xpath):
-  body = utils.download(url)
-  doc = BeautifulSoup(body)
+  doc = utils.beautifulsoup_from_url(url)
   results = doc.select(listing_xpath)
 
   if not results and not page_number:

--- a/inspectors/tigta.py
+++ b/inspectors/tigta.py
@@ -6,7 +6,6 @@ import os
 import re
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.treasury.gov/tigta/publications_semi.shtml

--- a/inspectors/tigta.py
+++ b/inspectors/tigta.py
@@ -46,7 +46,7 @@ def run(options):
       parse_result_from_js_url(url, "iereports", year, year_range, report_type='inspection')
 
   # Pull the congressional testimony
-  doc = BeautifulSoup(utils.download(CONGRESSIONAL_TESTIMONY_REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(CONGRESSIONAL_TESTIMONY_REPORTS_URL)
   results = doc.findAll("ul", type='disc')[0].select("li")
   for result in results:
     report = congressional_testimony_report_from(result, year_range)
@@ -54,7 +54,7 @@ def run(options):
       inspector.save_report(report)
 
   # Pull the semiannual reports
-  doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
   results = doc.findAll("ul", type='disc')[0].select("li")
   for result in results:
     report = semiannual_report_from(result, year_range)

--- a/inspectors/treasury.py
+++ b/inspectors/treasury.py
@@ -95,7 +95,7 @@ def run(options):
     if year < 2006:  # This is the oldest year for these reports
       continue
     url = AUDIT_REPORTS_BASE_URL.format(year)
-    doc = beautifulsoup_from_url(url)
+    doc = utils.beautifulsoup_from_url(url)
     results = doc.find_all("tr", class_=["ms-rteTableOddRow-default",
                                          "ms-rteTableEvenRow-default"])
     if not results:
@@ -106,7 +106,7 @@ def run(options):
         inspector.save_report(report)
 
   for report_type, url in OTHER_URLS.items():
-    doc = beautifulsoup_from_url(url)
+    doc = utils.beautifulsoup_from_url(url)
     results = doc.select("#ctl00_PlaceHolderMain_ctl05_ctl01__ControlWrapper_RichHtmlField > p a")
     if not results:
       raise inspector.NoReportsFoundError("Treasury (%s)" % report_type)
@@ -117,7 +117,7 @@ def run(options):
       if report:
         inspector.save_report(report)
 
-  doc = beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
+  doc = utils.beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
   results = doc.select("#ctl00_PlaceHolderMain_ctl05_ctl01__ControlWrapper_RichHtmlField > p > a")
   if not results:
     raise inspector.NoReportsFoundError("Treasury (semiannual reports)")
@@ -339,10 +339,5 @@ def semiannual_report_from(result, page_url, year_range):
     'published_on': datetime.datetime.strftime(published_on, "%Y-%m-%d"),
   }
   return report
-
-def beautifulsoup_from_url(url):
-  body = utils.download(url)
-  return BeautifulSoup(body)
-
 
 utils.run(run) if (__name__ == "__main__") else None

--- a/inspectors/treasury.py
+++ b/inspectors/treasury.py
@@ -6,7 +6,6 @@ import os
 import re
 from urllib.parse import urljoin, unquote
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.treasury.gov/about/organizational-structure/ig/Pages/audit_reports_index.aspx

--- a/inspectors/tva.py
+++ b/inspectors/tva.py
@@ -5,7 +5,6 @@ import logging
 import os
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://oig.tva.gov

--- a/inspectors/tva.py
+++ b/inspectors/tva.py
@@ -30,7 +30,7 @@ def run(options):
     if year < 2005:  # This is the earliest audits go back
       continue
     url = AUDIT_REPORTS_URL.format(year=year)
-    doc = BeautifulSoup(utils.download(url))
+    doc = utils.beautifulsoup_from_url(url)
     results = doc.select("div.content")
     if not results:
       raise inspector.NoReportsFoundError("Tennessee Valley Authority (%d)" % year)
@@ -40,7 +40,7 @@ def run(options):
         inspector.save_report(report)
 
   # Pull the semiannual reports
-  doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
   results = doc.select("report")
   if not results:
     raise inspector.NoReportsFoundError("Tennessee Valley Authority (semiannual reports)")

--- a/inspectors/usaid.py
+++ b/inspectors/usaid.py
@@ -36,7 +36,7 @@ def run(options):
   for report_type, report_url_format in PAGINATED_REPORT_FORMATS.items():
     for page in range(0, 999):
       url = report_url_format.format(page=page)
-      doc = BeautifulSoup(utils.download(url))
+      doc = utils.beautifulsoup_from_url(url)
       results = doc.select("li.views-row")
       if not results:
         if page == 0:
@@ -50,7 +50,7 @@ def run(options):
           inspector.save_report(report)
 
   # Pull the semiannual reports (no pagination)
-  doc = BeautifulSoup(utils.download(SEMIANNUAL_REPORTS_URL))
+  doc = utils.beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
   results = doc.select("li.views-row")
   if not results:
     raise inspector.NoReportsFoundError("USAID (semiannual reports)")
@@ -156,7 +156,7 @@ def semiannual_report_from(result, year_range):
     return
 
   landing_url = urljoin(SEMIANNUAL_REPORTS_URL, link.get('href'))
-  landing_page = BeautifulSoup(utils.download(landing_url))
+  landing_page = utils.beautifulsoup_from_url(landing_url)
 
   report_url = landing_page.select("div.filefield-file a")[0].get('href')
   report_filename = report_url.split("/")[-1]

--- a/inspectors/usaid.py
+++ b/inspectors/usaid.py
@@ -6,7 +6,6 @@ import os
 import re
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # https://oig.usaid.gov

--- a/inspectors/usps.py
+++ b/inspectors/usps.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from utils import utils, inspector
-from bs4 import BeautifulSoup
 from datetime import datetime
 import logging
 import os.path

--- a/inspectors/usps.py
+++ b/inspectors/usps.py
@@ -64,8 +64,7 @@ def run(options):
         logging.debug("## Downloading %s, page %i, attempt %i" % \
                              (category_name, page, retry))
         url = url_for(options, page, category_id)
-        body = utils.download(url)
-        doc = BeautifulSoup(body)
+        doc = utils.beautifulsoup_from_url(url)
 
         results = doc.select(".views-row")
         if not results:
@@ -120,8 +119,7 @@ def run(options):
 
 def get_last_page(options, category_id):
   url = url_for(options, 1, category_id)
-  body = utils.download(url)
-  doc = BeautifulSoup(body)
+  doc = utils.beautifulsoup_from_url(url)
   return last_page_for(doc)
 
 def get_timestamp(result):

--- a/inspectors/utils/utils.py
+++ b/inspectors/utils/utils.py
@@ -11,6 +11,7 @@ import urllib.parse
 import io
 import gzip
 import certifi
+from urllib.parse import urljoin
 
 from . import admin
 
@@ -244,7 +245,14 @@ def beautifulsoup_from_url(url):
   body = download(url)
   if body is None: return None
 
-  return BeautifulSoup(body, "lxml")
+  doc = BeautifulSoup(body, "lxml")
+
+  # Some of the pages will return meta refreshes
+  if doc.find("meta") and doc.find("meta").attrs.get('http-equiv') == 'REFRESH':
+    redirect_url = urljoin(url, doc.find("meta").attrs['content'].split("url=")[1])
+    return beautifulsoup_from_url(redirect_url)
+  else:
+    return doc
 
 def post(url, data=None, headers=None, **kwargs):
   response = None

--- a/inspectors/utils/utils.py
+++ b/inspectors/utils/utils.py
@@ -240,6 +240,12 @@ def download(url, destination=None, options=None):
     # whether from disk or web, unescape HTML entities
     return unescape(body)
 
+def beautifulsoup_from_url(url):
+  body = download(url)
+  if body is None: return None
+
+  return BeautifulSoup(body, "lxml")
+
 def post(url, data=None, headers=None, **kwargs):
   response = None
   try:
@@ -273,7 +279,7 @@ def log_http_error(e, url):
 # then writes it and returns the /data-relative path.
 def text_from_html(real_html_path, real_text_path):
   html = open(real_html_path, encoding='utf-8').read()
-  doc = BeautifulSoup(html)
+  doc = BeautifulSoup(html, "lxml")
 
   for node in doc.findAll(['script', 'style']):
     node.extract()

--- a/inspectors/va.py
+++ b/inspectors/va.py
@@ -56,7 +56,7 @@ def run(options):
 
   # Pull the audit reports
   for page in range(1, 1000):
-    doc = beautifulsoup_from_url("{}?RS={}".format(REPORTS_URL, page))
+    doc = utils.beautifulsoup_from_url("{}?RS={}".format(REPORTS_URL, page))
     results = doc.select("div.leadin")
     if not results:
       if page == 1:
@@ -69,7 +69,7 @@ def run(options):
         inspector.save_report(report)
 
   # Pull the semiannual reports
-  doc = beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
+  doc = utils.beautifulsoup_from_url(SEMIANNUAL_REPORTS_URL)
   results = doc.select("div.leadin")
   if not results:
     raise inspector.NoReportsFoundError("VA (semiannual reports)")
@@ -110,7 +110,7 @@ def report_from(result, year_range):
   # These pages occassionally return text indicating there was a temporary
   # error so we will retry if necessary.
   for attempt in range(MAX_ATTEMPTS):
-    landing_page = beautifulsoup_from_url(landing_url)
+    landing_page = utils.beautifulsoup_from_url(landing_url)
     page_text = landing_page.select("div.report-summary")[0].text.strip()
     if page_text != ERROR_PAGE_TEXT:
       break
@@ -207,10 +207,6 @@ def semiannual_report_from(result, year_range):
     'published_on': datetime.datetime.strftime(published_on, "%Y-%m-%d"),
   }
   return report
-
-def beautifulsoup_from_url(url):
-  body = utils.download(url)
-  return BeautifulSoup(body)
 
 def br_to_newline(subtree):
   br = subtree.find("br")

--- a/inspectors/va.py
+++ b/inspectors/va.py
@@ -5,7 +5,6 @@ import logging
 import os
 import time
 
-from bs4 import BeautifulSoup
 from utils import utils, inspector
 
 # http://www.va.gov/oig/apps/info/OversightReports.aspx

--- a/scraper.py.template
+++ b/scraper.py.template
@@ -34,7 +34,7 @@ def run(options):
   year_range = inspector.year_range(options)
 
   # Pull the reports
-  doc = BeautifulSoup(utils.download(REPORTS_URL))
+  doc = utils.beautifulsoup_from_html(REPORTS_URL)
   results = doc.select("some-selector")
   for result in results:
     report = report_from(result, year_range)


### PR DESCRIPTION
I have explicitly set the code to use `lxml` as the HTML processor for BeautifulSoup. In addition, I have refactored most of the inspectors to replace the call to `utils.download` followed by a `BeautifulSoup(body)` call with single `utils.beautifulsoup_from_url` lines. This reduced the number of places in the code with BeautifulSoup was instantiated, but there are some exceptions, usually because the scraper is using a post request instead. In the case of HHS, they do a bit more with the response as well.

I have noticed a few scraping errors when testing this change out in the following scrapers:
- CFTC
- DOT
- EPA
- FCA
- HHS
- NCUA
- SEC
- Treasury
- USPS

Many of these look to be issues with changes in the page structure/URLs of the IG sites, but until I can investigate, this PR should be considered a WORK IN PROGRESS and probably not be merged quite yet. Thank you.