### PR TITLE
Don't use form feed char in PDF text extraction

### DIFF
--- a/inspectors/utils/utils.py
+++ b/inspectors/utils/utils.py
@@ -324,7 +324,7 @@ def text_from_pdf(real_pdf_path, real_text_path):
     return
 
   try:
-    subprocess.check_call(["pdftotext", "-layout", real_pdf_path, real_text_path], shell=False)
+    subprocess.check_call(["pdftotext", "-layout", "-nopgbrk", real_pdf_path, real_text_path], shell=False)
   except subprocess.CalledProcessError as exc:
     logging.warn("Error extracting text to %s:\n\n%s" % (real_text_path, format_exception(exc)))
     return


### PR DESCRIPTION
`pdftotext` inserts a form feed character by default at each page break. This adds a command line switch to disable that behavior, since we don't use it, and it causes problems further down the toolchain.