### PR TITLE
More fixes

### DIFF
--- a/inspectors/cpsc.py
+++ b/inspectors/cpsc.py
@@ -3,7 +3,6 @@
 import datetime
 import logging
 import os
-import re
 from urllib.parse import urljoin
 
 from utils import utils, inspector
@@ -55,9 +54,13 @@ def report_from(result, year_range):
   if report_url in BLACKLIST_REPORT_URLS:
     return
 
+  # Follow redirects to get real file names
+  if report_url.startswith("http://www.cpsc.gov/Media/"):
+    report_url = utils.resolve_redirect(report_url)
+
   # URLs with /PageFiles in them need to use the filename and its
   # directory to be unique. Other URLs can just use the filename.
-  if re.compile("PageFiles").search(report_url):
+  if "PageFiles" in report_url:
     # e.g. /../132643/fy11fisma.pdf -> 132643-fy11fisma.pdf
     report_filename = str.join("-", report_url.split("/")[-2:])
   else:

--- a/inspectors/denali.py
+++ b/inspectors/denali.py
@@ -21,6 +21,7 @@ archive = 2006
 REPORTS_URL = "http://oig.denali.gov"
 
 REPORT_PUBLISHED_MAPPING = {
+  "DCOIG-16-001-A": datetime.datetime(2015, 11, 13),
   "FY-14-Denali-Commission-Financial-Performance-Report": datetime.datetime(2014, 11, 26),
   "FY-12-Denali-Commission-Financial-Report": datetime.datetime(2012, 11, 15),
   "FY-11-Denali-Commission-Financial-Report": datetime.datetime(2011, 11, 22),

--- a/inspectors/dod.py
+++ b/inspectors/dod.py
@@ -93,12 +93,12 @@ def any_pdf_test(tag):
   is_pdf = (RE_PDF_HREF.search(tag['href']) or RE_BACKUP_PDF_HREF.search(tag['href']))
   return is_pdf
 
-RE_OFFICIAL = re.compile('For Official Use Only', re.I)
+RE_OFFICIAL = re.compile('For\\s+Official\\s+Use\\s+Only', re.I)
 RE_CLASSIFIED = re.compile('Classified', re.I)
 RE_INTEL = re.compile('-INTEL-') # case-sensitive
-RE_FOIA = re.compile('Freedom (?:of|on) Information Act', re.I)
+RE_FOIA = re.compile('Freedom\\s+(?:of|on)\\s+Information\\s+Act', re.I)
 RE_RESTRICTED = re.compile('Restricted', re.I)
-RE_AFGHANISTAN = re.compile('Provided to the Security Forces of Afghanistan', re.I)
+RE_AFGHANISTAN = re.compile('Provided\\s+to\\s+the\\s+Security\\s+Forces\\s+of\\s+Afghanistan', re.I)
 
 # Landing pages to be skipped (dupes, etc.)
 LANDING_PAGE_BLACKLIST = [

--- a/inspectors/epa.py
+++ b/inspectors/epa.py
@@ -156,6 +156,7 @@ def report_from_table(tds, published_on_dt, base_url):
       if "Report At A Glance" in text or "Report At a Glance" in text:
         report['summary_url'] = absolute_href
       elif ("Full Report" in text or
+            "Full Semiannual Report" in text or
             "Full Compendium" in text or
             "Full Document" in text or
             "Key Management Challenges Memorandum" in text):

--- a/inspectors/fmc.py
+++ b/inspectors/fmc.py
@@ -47,8 +47,8 @@ def run(options):
   results = doc.select("table tr")
   if not results:
     raise inspector.NoReportsFoundError("Federal Maritime Commission (audits)")
-  for index, result in enumerate(results):
-    if not index:
+  for result in results:
+    if result.th:
       # Skip the header row
       continue
     report = report_from(result, AUDIT_REPORTS_URL, report_type='audit', year_range=year_range)
@@ -66,8 +66,8 @@ def run(options):
       results = doc.select("div.col-2-2 ul")[1:-1]
     if not results:
       raise inspector.NoReportsFoundError("Federal Maritime Commission (%s)" % audit_year_url)
-    for index, result in enumerate(results):
-      if not index:
+    for result in results:
+      if result.th:
         # Skip the header row
         continue
       report = report_from(result, AUDIT_REPORTS_URL, report_type='audit', year_range=year_range)

--- a/inspectors/lsc.py
+++ b/inspectors/lsc.py
@@ -40,14 +40,14 @@ REPORT_PUBLISHED_MAP = {
   "MeekerOIGMappingReport": datetime.datetime(2005, 9, 14),
   "core-legal-services": datetime.datetime(2005, 3, 14),
   "Mapping_Evaluation_Phase_I_Volume_I_Final_Report": datetime.datetime(2003, 11, 1),
-  "evalicls": datetime.datetime(2005, 11, 1),
-  "evallafla": datetime.datetime(2004, 11, 1),
-  "evallasoc": datetime.datetime(2004, 11, 1),
-  "evallassd": datetime.datetime(2004, 11, 1),
-  "evalnls": datetime.datetime(2004, 11, 1),
-  "evalalas": datetime.datetime(2005, 11, 1),
-  "evalglsp": datetime.datetime(2005, 11, 1),
-  "evalmlsa": datetime.datetime(2005, 11, 1),
+  "EvalICLS": datetime.datetime(2005, 11, 1),
+  "EvalLAFLA": datetime.datetime(2004, 11, 1),
+  "EvalLASOC": datetime.datetime(2004, 11, 1),
+  "EvalLASSD": datetime.datetime(2004, 11, 1),
+  "EvalNLS": datetime.datetime(2004, 11, 1),
+  "EvalALAS": datetime.datetime(2005, 11, 1),
+  "EvalGLSP": datetime.datetime(2005, 11, 1),
+  "EvalMLSA": datetime.datetime(2005, 11, 1),
   "fraud-alert-16-01": datetime.datetime(2015, 10, 19),
 }
 
@@ -147,9 +147,9 @@ def parse_mapping(content, landing_url, report_type, year_range):
       result = link.parent
     elif href == "https://www.oig.lsc.gov/images/mapping/Mapping_Evaluation_Phase_I_Volume_I_Final_Report.pdf":
       result = link.parent.parent
-    elif (href.startswith("https://oig.lsc.gov/mapping/references/eval") and
+    elif (href.startswith("https://www.oig.lsc.gov/images/Eval") and
           href.endswith(".pdf")):
-      result = link
+      result = link.parent
     else:
       raise Exception("Unexpected link found on a mapping project page: %s"
                       % href)
@@ -200,6 +200,10 @@ def report_from(result, landing_url, report_type, year_range, year=None):
     title = inspector.sanitize(result.text)
   report_url = urljoin(landing_url, report_url)
   report_filename = os.path.basename(report_url)
+
+  if title.endswith("PDF"):
+    title = title[:-3]
+  title = title.rstrip(" .")
 
   prev = result.previous_sibling
   if isinstance(prev, NavigableString) and "See, also:" in prev:


### PR DESCRIPTION
This fixes six different scrapers that have been showing up in [#errors](https://oversight.slack.com/messages/errors) lately. Mostly dates, bookkeeping, and heuristic fixes.