### PR TITLE
TLS changes

### DIFF
--- a/inspectors/ncua.py
+++ b/inspectors/ncua.py
@@ -8,7 +8,7 @@ from urllib.parse import urljoin
 
 from utils import utils, inspector
 
-# http://www.ncua.gov/About/Pages/inspector-general.aspx
+# https://www.ncua.gov/About/Pages/inspector-general.aspx
 archive = 1999
 
 # options:
@@ -17,11 +17,11 @@ archive = 1999
 # Notes for IG's web team:
 #
 
-HOMEPAGE_URL = "http://www.ncua.gov/About/Pages/inspector-general.aspx"
-AUDIT_REPORTS_URL = "http://www.ncua.gov/About/Pages/inspector-general/audit-reports/{year}.aspx"
-SEMIANNUAL_REPORTS_URL = "http://www.ncua.gov/About/Pages/inspector-general/semiannual-reports.aspx"
-OTHER_REPORTS_URL = "http://www.ncua.gov/About/Pages/inspector-general/other-reports.aspx"
-PLANS_URL = "http://www.ncua.gov/About/Pages/inspector-general/performance-strategic-plans.aspx"
+HOMEPAGE_URL = "https://www.ncua.gov/About/Pages/inspector-general.aspx"
+AUDIT_REPORTS_URL = "https://www.ncua.gov/About/Pages/inspector-general/audit-reports/{year}.aspx"
+SEMIANNUAL_REPORTS_URL = "https://www.ncua.gov/About/Pages/inspector-general/semiannual-reports.aspx"
+OTHER_REPORTS_URL = "https://www.ncua.gov/About/Pages/inspector-general/other-reports.aspx"
+PLANS_URL = "https://www.ncua.gov/About/Pages/inspector-general/performance-strategic-plans.aspx"
 # Note: There is no need to scrape the "Material Loss Reviews" page, since
 # these reports are included with the audit reports for each year.
 

--- a/inspectors/utils/utils.py
+++ b/inspectors/utils/utils.py
@@ -108,7 +108,7 @@ scraper.mount("https://www.sba.gov/", Tls1HttpAdapter())
 # The IGnet and FHFA OIG websites require extra certificate downloads, as of
 # 10/2/2015
 WHITELIST_INSECURE_DOMAINS = (
-  "https://www.ignet.gov/",
+  "https://www.ignet.gov/",  # incomplete chain as of 1/25/2015
   "https://www.ncua.gov/",  # incomplete chain as of 12/5/2015
 
   # The following domains will 301/302 redirect to the above domains, so

--- a/inspectors/utils/utils.py
+++ b/inspectors/utils/utils.py
@@ -110,6 +110,7 @@ scraper.mount("https://www.sba.gov/", Tls1HttpAdapter())
 WHITELIST_INSECURE_DOMAINS = (
   "https://www.ignet.gov/",
   "https://origin.www.fhfaoig.gov/",
+  "https://www.ncua.gov/",  # incomplete chain as of 12/5/2015
 
   # The following domains will 301/302 redirect to the above domains, so
   # validate=False is needed for these cases as well
@@ -117,6 +118,7 @@ WHITELIST_INSECURE_DOMAINS = (
   "http://ignet.gov/",
   "http://www.fhfaoig.gov/",
   "http://fhfaoig.gov/",
+  "http://www.ncua.gov/",
 )
 WHITELIST_SHA1_DOMAINS = (
   "https://www.sba.gov/",

--- a/inspectors/utils/utils.py
+++ b/inspectors/utils/utils.py
@@ -109,15 +109,12 @@ scraper.mount("https://www.sba.gov/", Tls1HttpAdapter())
 # 10/2/2015
 WHITELIST_INSECURE_DOMAINS = (
   "https://www.ignet.gov/",
-  "https://origin.www.fhfaoig.gov/",
   "https://www.ncua.gov/",  # incomplete chain as of 12/5/2015
 
   # The following domains will 301/302 redirect to the above domains, so
   # validate=False is needed for these cases as well
   "http://www.ignet.gov/",
   "http://ignet.gov/",
-  "http://www.fhfaoig.gov/",
-  "http://fhfaoig.gov/",
   "http://www.ncua.gov/",
 )
 WHITELIST_SHA1_DOMAINS = (


### PR DESCRIPTION
NCUA is now all-HTTPS, though the chain is incomplete. (I emailed the webmaster about that) FHFA works now, and can be taken off the whitelist. CIGIE is still serving an incomplete chain.