### PR TITLE
Fix dictionaries with duplicate keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,16 @@ sudo: false
 
 install:
   - pip install -r requirements.txt
-    pip install pyflakes pylint
+  - pip install pyflakes pylint
 
 script:
   - pyflakes .
-    pylint --disable=all --enable=duplicate-key inspectors/*.py inspectors/utils/*.py scripts/*.py igs qa backup
+  - pylint --disable=all --enable=duplicate-key inspectors/*.py inspectors/utils/*.py scripts/*.py igs qa backup
 
 notifications:
   email:
     recipients:
       - spulec@gmail.com
-        eric@konklone.com
+      - eric@konklone.com
     on_success: change
     on_failure: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,16 @@ sudo: false
 
 install:
   - pip install -r requirements.txt
-  - pip install pyflakes
+    pip install pyflakes pylint
 
-script: pyflakes .
+script:
+  - pyflakes .
+    pylint --disable=all --enable=duplicate-key inspectors/*.py inspectors/utils/*.py scripts/*.py igs qa backup
 
 notifications:
   email:
     recipients:
       - spulec@gmail.com
-      - eric@konklone.com
+        eric@konklone.com
     on_success: change
     on_failure: change

--- a/inspectors/doj.py
+++ b/inspectors/doj.py
@@ -63,7 +63,6 @@ agency_decoder = {
     "Bureau of Alcohol, Tobacco, Firearms and Explosives (ATF)": ["Bureau of Alcohol, Tobacco, Firearms and Explosives", "ATF"],
     "Office on Violence Against Women (OVW)": ["Office on Violence Against Women", "OVW"],
     "Immigration and Naturalization Service (INS) – 1994 to 2003": ["Immigration and Naturalization Service", "INS"],
-    "United States Marshals Service (USMS)": ["United States Marshals Service", "USMS"],
 }
 
 not_agency = (

--- a/inspectors/eac.py
+++ b/inspectors/eac.py
@@ -24,20 +24,20 @@ CONGRESSIONAL_REPORTS_URL = "http://www.eac.gov/inspector_general/congressional_
 INVESTIGATIONS_URL = "http://www.eac.gov/inspector_general/investigation_reports.aspx"
 PEER_REVIEWS_URL = "http://www.eac.gov/inspector_general/peer_review_reports.aspx"
 
-REPORT_URLS = {
-  "testimony": CONGRESSIONAL_TESTIMONY_URL,
-  "audit": HAVA_AUDITS_URL,
-  "audit": EAC_AUDITS_URL,
-  "congress": CONGRESSIONAL_REPORTS_URL,
-  "investigation": INVESTIGATIONS_URL,
-  "peer_review": PEER_REVIEWS_URL,
-}
+REPORT_URLS = [
+  ("testimony", CONGRESSIONAL_TESTIMONY_URL),
+  ("audit", HAVA_AUDITS_URL),
+  ("audit", EAC_AUDITS_URL),
+  ("congress", CONGRESSIONAL_REPORTS_URL),
+  ("investigation", INVESTIGATIONS_URL),
+  ("peer_review", PEER_REVIEWS_URL),
+]
 
 def run(options):
   year_range = inspector.year_range(options, archive)
 
   # Pull the reports
-  for report_type, url in REPORT_URLS.items():
+  for report_type, url in REPORT_URLS:
     doc = utils.beautifulsoup_from_url(url)
     results = doc.select("div.mainRegion p a")
     if not results:

--- a/inspectors/education.py
+++ b/inspectors/education.py
@@ -32,13 +32,13 @@ CONGRESSIONAL_TESTIMONY_URL = "https://www2.ed.gov/about/offices/list/oig/testim
 SPECIAL_REPORTS_URL = "https://www2.ed.gov/about/offices/list/oig/specialreportstocongress.html"
 OTHER_REPORTS_URL = "https://www2.ed.gov/about/offices/list/oig/otheroigproducts.html"
 
-OTHER_REPORTS_URL = {
-  "other": OTHER_REPORTS_URL,
-  "other": SPECIAL_REPORTS_URL,
-  "testimony": CONGRESSIONAL_TESTIMONY_URL,
-  "investigation": INVESTIGATIVE_REPORTS_URL,
-  "inspection": INSPECTION_REPORTS_URL,
-}
+OTHER_REPORTS_URLS = [
+  ("other", OTHER_REPORTS_URL),
+  ("other", SPECIAL_REPORTS_URL),
+  ("testimony", CONGRESSIONAL_TESTIMONY_URL),
+  ("investigation", INVESTIGATIVE_REPORTS_URL),
+  ("inspection", INSPECTION_REPORTS_URL),
+]
 
 REPORT_PUBLISHED_MAP = {
   "statelocal032002": datetime.datetime(2002, 3, 21),
@@ -100,7 +100,7 @@ def run(options):
       inspector.save_report(report)
 
   # Get other reports
-  for report_type, url in OTHER_REPORTS_URL.items():
+  for report_type, url in OTHER_REPORTS_URLS:
     doc = utils.beautifulsoup_from_url(url)
     results = doc.select("div.contentText ul li")
     if not results:
@@ -277,6 +277,12 @@ def report_from(result, url, report_type, year_range):
     return
 
   if "thestartingline.ed.gov" in report_url:
+    return None
+
+  if (report_id in ("x13j0003", "x19k0008", "x05j0019") and
+      url == OTHER_REPORTS_URL):
+    # These reports are also posted on the audit report pages, so we skip the
+    # copy on the other reports page
     return None
 
   key = (report_id, title, report_url)

--- a/inspectors/flra.py
+++ b/inspectors/flra.py
@@ -22,19 +22,19 @@ QA_REVIEWS_URL = "https://www.flra.gov/OIG_QA_Reviews"
 SEMIANNUAL_REPORTS_URL = "https://www.flra.gov/IG_semi-annual_reports"
 PEER_REVIEWS_URL = "https://www.flra.gov/OIG-PEER-REVIEW"
 
-REPORT_URLS = {
-  "audit": AUDIT_REPORTS_URL,
-  "inspection": INTERNAL_REVIEWS_URL,
-  "inspection": QA_REVIEWS_URL,
-  "semiannual_report": SEMIANNUAL_REPORTS_URL,
-  "peer_review": PEER_REVIEWS_URL,
-}
+REPORT_URLS = [
+  ("audit", AUDIT_REPORTS_URL),
+  ("inspection", INTERNAL_REVIEWS_URL),
+  ("inspection", QA_REVIEWS_URL),
+  ("semiannual_report", SEMIANNUAL_REPORTS_URL),
+  ("peer_review", PEER_REVIEWS_URL),
+]
 
 def run(options):
   year_range = inspector.year_range(options, archive)
 
   # Pull the reports
-  for report_type, url in REPORT_URLS.items():
+  for report_type, url in REPORT_URLS:
     doc = utils.beautifulsoup_from_url(url)
     results = doc.select("div.node ul li")
     if not results:
@@ -60,8 +60,18 @@ def report_from(result, landing_url, report_type, year_range):
     # Some reports have incorrect relative paths
     relative_report_url = link.get('href').replace("../", "")
     report_url = urljoin(landing_url, relative_report_url)
+    if report_url == "http://ignet.gov/internal/flra/03govveh.pdf":
+      report_url = "https://www.flra.gov/webfm_send/395"
     report_filename = report_url.split("/")[-1]
     report_id, _ = os.path.splitext(report_filename)
+
+  if (title == "Financial Statement Audit for Fiscal Year 2007" and
+      report_id == "internalcontrolindpaud08"):
+    # This link points to the wrong report, mark FY2007 financial statement
+    # audit as unreleased
+    report_id = "-".join(title.split())
+    unreleased = True
+    report_url = None
 
   estimated_date = False
   try:

--- a/inspectors/sigar.py
+++ b/inspectors/sigar.py
@@ -20,17 +20,17 @@ SPOTLIGHT_REPORTS_URL = "https://www.sigar.mil/Newsroom/spotlight/spotlight.xml"
 SPEECHES_REPORTS_URL = "https://www.sigar.mil/Newsroom/speeches/speeches.xml"
 TESTIMONY_REPORTS_URL = "https://www.sigar.mil/Newsroom/testimony/testimony.xml"
 
-REPORT_URLS = {
-  "other": SPOTLIGHT_REPORTS_URL,
-  "press": SPEECHES_REPORTS_URL,
-  "testimony": TESTIMONY_REPORTS_URL,
-  "audit": "https://www.sigar.mil/audits/auditreports/reports.xml",
-  "inspection": "https://www.sigar.mil/audits/inspectionreports/inspection-reports.xml",
-  "audit": "https://www.sigar.mil/audits/financialreports/Financial-Audits.xml",
-  "other": "https://www.sigar.mil/SpecialProjects/projectreports/reports.xml",
-  "other": "https://www.sigar.mil/Audits/alertandspecialreports/alert-special-reports.xml",
-  "semiannual_report": "https://www.sigar.mil/quarterlyreports/index.xml",
-}
+REPORT_URLS = [
+  ("other", SPOTLIGHT_REPORTS_URL),
+  ("press", SPEECHES_REPORTS_URL),
+  ("testimony", TESTIMONY_REPORTS_URL),
+  ("audit", "https://www.sigar.mil/audits/auditreports/reports.xml"),
+  ("inspection", "https://www.sigar.mil/audits/inspectionreports/inspection-reports.xml"),
+  ("audit", "https://www.sigar.mil/audits/financialreports/Financial-Audits.xml"),
+  ("other", "https://www.sigar.mil/SpecialProjects/projectreports/reports.xml"),
+  ("other", "https://www.sigar.mil/Audits/alertandspecialreports/alert-special-reports.xml"),
+  ("semiannual_report", "https://www.sigar.mil/quarterlyreports/index.xml"),
+]
 
 BASE_REPORT_URL = "https://www.sigar.mil/allreports/index.aspx"
 
@@ -38,7 +38,7 @@ def run(options):
   year_range = inspector.year_range(options, archive)
 
   # Pull the reports
-  for report_type, report_url in REPORT_URLS.items():
+  for report_type, report_url in REPORT_URLS:
     doc = utils.beautifulsoup_from_url(report_url)
     results = doc.select("item")
     if not results:
@@ -57,6 +57,10 @@ def report_from(result, landing_url, report_type, year_range):
 
   published_on_text = result.find("pubdate").text.strip()
   published_on = datetime.datetime.strptime(published_on_text, '%A, %B %d, %Y')
+
+  if report_id == "SIGAR-14-42-AL" and title == "SIGAR 14-42-AL":
+    # this report is posted in both "spotlight" and "special reports"
+    return
 
   if published_on.year not in year_range:
     logging.debug("[%s] Skipping, not in requested range." % report_url)

--- a/inspectors/sigtarp.py
+++ b/inspectors/sigtarp.py
@@ -15,18 +15,18 @@ archive = 2009
 # Notes for IG's web team:
 #
 
-REPORT_URLS = {
-  "semiannual_report": "https://www.sigtarp.gov/pages/quarterly.aspx",
-  "audit": "https://www.sigtarp.gov/pages/audit.aspx",
-  "audit": "https://www.sigtarp.gov/pages/auditrc.aspx",
-  "audit": "https://www.sigtarp.gov/pages/engmem.aspx",
-}
+REPORT_URLS = [
+  ("semiannual_report", "https://www.sigtarp.gov/pages/quarterly.aspx"),
+  ("audit", "https://www.sigtarp.gov/pages/audit.aspx"),
+  ("audit", "https://www.sigtarp.gov/pages/auditrc.aspx"),
+  ("audit", "https://www.sigtarp.gov/pages/engmem.aspx"),
+]
 
 def run(options):
   year_range = inspector.year_range(options, archive)
 
   # Pull the reports
-  for report_type, report_url in REPORT_URLS.items():
+  for report_type, report_url in REPORT_URLS:
     doc = utils.beautifulsoup_from_url(report_url)
     results =  doc.select("td.mainInner div.ms-WPBody li")
 


### PR DESCRIPTION
Pyflakes wss not warning on duplicate keys in dictionary literals. In
each case, only the last value will remain in the dictionary. As a
result, some pages were not being crawled. This fixes the six scrapers
with the issue and adds pylint to the CI script to prevent regressions.